### PR TITLE
RDKE-652 : Update Copyright and License in linux_binder_aidl

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,5 @@
-# *
-# * If not stated otherwise in this file or this component's LICENSE file the
-# * following copyright and licenses apply:
-# *
-# * Copyright (C) 2024 Sky
+#/**
+# * Copyright 2024 Comcast Cable Communications Management, LLC
 # *
 # * Licensed under the Apache License, Version 2.0 (the "License");
 # * you may not use this file except in compliance with the License.
@@ -16,6 +13,8 @@
 # * See the License for the specific language governing permissions and
 # * limitations under the License.
 # *
+# * SPDX-License-Identifier: Apache-2.0
+# */
 
 # ** @brief : Build binder idl module
 # *

--- a/NOTICE
+++ b/NOTICE
@@ -1,6 +1,25 @@
-This component contains software that is Copyright (c) 2024 Sky.
-The component is licensed to you under the Apache License, Version 2.0 (the "License").
-You may not use the component except in compliance with the License.
+[linux_binder_idl]
+Copyright 2024 Comcast Cable Communications Management, LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+SPDX-License-Identifier: Apache-2.0
+
+This product includes software developed at Comcast (http://www.comcast.com/)
+
+The component may include material which is licensed under other licenses / copyrights as
+listed below. Your use of this material within the component is also subject to the terms and
+conditions of these licenses. The LICENSE file contains the text of all the licenses which apply
+within this component.
 
 This product includes the AIDL framework developed as part of
 The Android Open Source Project (http://source.android.com).

--- a/aidl-generator/CMakeLists.txt
+++ b/aidl-generator/CMakeLists.txt
@@ -1,8 +1,5 @@
-# *
-# * If not stated otherwise in this file or this component's LICENSE file the
-# * following copyright and licenses apply:
-# *
-# * Copyright (C) 2024 Sky
+#/**
+# * Copyright 2024 Comcast Cable Communications Management, LLC
 # *
 # * Licensed under the Apache License, Version 2.0 (the "License");
 # * you may not use this file except in compliance with the License.
@@ -16,6 +13,8 @@
 # * See the License for the specific language governing permissions and
 # * limitations under the License.
 # *
+# * SPDX-License-Identifier: Apache-2.0
+# */
 
 # **@brief
 # * The cmake is used to build the Android aidl compiler module (aidl generator tool)

--- a/build-aidl-generator-tool.sh
+++ b/build-aidl-generator-tool.sh
@@ -1,10 +1,7 @@
 #!/bin/sh
 
-# *
-# * If not stated otherwise in this file or this component's LICENSE file the
-# * following copyright and licenses apply:
-# *
-# * Copyright (C) 2024 Sky
+#/**
+# * Copyright 2024 Comcast Cable Communications Management, LLC
 # *
 # * Licensed under the Apache License, Version 2.0 (the "License");
 # * you may not use this file except in compliance with the License.
@@ -18,6 +15,8 @@
 # * See the License for the specific language governing permissions and
 # * limitations under the License.
 # *
+# * SPDX-License-Identifier: Apache-2.0
+# */
 
 # ** @brief : Build aidl utility for host machine.
 # *

--- a/build-binder-example.sh
+++ b/build-binder-example.sh
@@ -1,10 +1,7 @@
 #!/bin/sh
 
-# *
-# * If not stated otherwise in this file or this component's LICENSE file the
-# * following copyright and licenses apply:
-# *
-# * Copyright (C) 2024 Sky
+#/**
+# * Copyright 2024 Comcast Cable Communications Management, LLC
 # *
 # * Licensed under the Apache License, Version 2.0 (the "License");
 # * you may not use this file except in compliance with the License.
@@ -18,6 +15,8 @@
 # * See the License for the specific language governing permissions and
 # * limitations under the License.
 # *
+# * SPDX-License-Identifier: Apache-2.0
+# */
 
 # ** @brief : Build linux binder idl.
 # *

--- a/build-linux-binder-aidl.sh
+++ b/build-linux-binder-aidl.sh
@@ -1,10 +1,7 @@
 #!/bin/sh
 
-# *
-# * If not stated otherwise in this file or this component's LICENSE file the
-# * following copyright and licenses apply:
-# *
-# * Copyright (C) 2024 Sky
+#/**
+# * Copyright 2024 Comcast Cable Communications Management, LLC
 # *
 # * Licensed under the Apache License, Version 2.0 (the "License");
 # * you may not use this file except in compliance with the License.
@@ -18,6 +15,8 @@
 # * See the License for the specific language governing permissions and
 # * limitations under the License.
 # *
+# * SPDX-License-Identifier: Apache-2.0
+# */
 
 # ** @brief : Build linux binder idl.
 # *

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -1,8 +1,5 @@
-# *
-# * If not stated otherwise in this file or this component's LICENSE file the
-# * following copyright and licenses apply:
-# *
-# * Copyright (C) 2024 Sky
+#/**
+# * Copyright 2024 Comcast Cable Communications Management, LLC
 # *
 # * Licensed under the Apache License, Version 2.0 (the "License");
 # * you may not use this file except in compliance with the License.
@@ -16,6 +13,8 @@
 # * See the License for the specific language governing permissions and
 # * limitations under the License.
 # *
+# * SPDX-License-Identifier: Apache-2.0
+# */
 
 # ** @brief : Build binder example module
 # *           The cmake is used to build the FWManager binder example module.

--- a/example/FWManager/CMakeLists.txt
+++ b/example/FWManager/CMakeLists.txt
@@ -1,8 +1,5 @@
-# *
-# * If not stated otherwise in this file or this component's LICENSE file the
-# * following copyright and licenses apply:
-# *
-# * Copyright (C) 2024 Sky
+#/**
+# * Copyright 2024 Comcast Cable Communications Management, LLC
 # *
 # * Licensed under the Apache License, Version 2.0 (the "License");
 # * you may not use this file except in compliance with the License.
@@ -16,6 +13,8 @@
 # * See the License for the specific language governing permissions and
 # * limitations under the License.
 # *
+# * SPDX-License-Identifier: Apache-2.0
+# */
 
 # ** @brief : Build FWManager binder example module
 # *           The cmake is used to build the FWManagerService and FWManagerClient module.

--- a/example/FWManager/aidl/com/test/FirmwareStatus.aidl
+++ b/example/FWManager/aidl/com/test/FirmwareStatus.aidl
@@ -1,8 +1,5 @@
-/*
- * If not stated otherwise in this file or this component's LICENSE file the
- * following copyright and licenses apply:
- *
- * Copyright (C) 2024 Sky
+/**
+ * Copyright 2024 Comcast Cable Communications Management, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,6 +12,8 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 /** @brief

--- a/example/FWManager/aidl/com/test/IFWManager.aidl
+++ b/example/FWManager/aidl/com/test/IFWManager.aidl
@@ -1,8 +1,5 @@
-/*
- * If not stated otherwise in this file or this component's LICENSE file the
- * following copyright and licenses apply:
- *
- * Copyright (C) 2024 Sky
+/**
+ * Copyright 2024 Comcast Cable Communications Management, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,6 +12,8 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 /** @brief

--- a/example/FWManager/aidl/com/test/IFirmwareUpdateStateListener.aidl
+++ b/example/FWManager/aidl/com/test/IFirmwareUpdateStateListener.aidl
@@ -1,8 +1,5 @@
-/*
- * If not stated otherwise in this file or this component's LICENSE file the
- * following copyright and licenses apply:
- *
- * Copyright (C) 2024 Sky
+/**
+ * Copyright 2024 Comcast Cable Communications Management, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,6 +12,8 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 /** @brief

--- a/example/FWManager/client/FWManagerClient.cpp
+++ b/example/FWManager/client/FWManagerClient.cpp
@@ -1,8 +1,5 @@
-/*
- * If not stated otherwise in this file or this component's LICENSE file the
- * following copyright and licenses apply:
- *
- * Copyright (C) 2024 Sky
+/**
+ * Copyright 2024 Comcast Cable Communications Management, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,6 +12,8 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 /** @brief

--- a/example/FWManager/service/FWManager.cpp
+++ b/example/FWManager/service/FWManager.cpp
@@ -1,8 +1,5 @@
-/*
- * If not stated otherwise in this file or this component's LICENSE file the
- * following copyright and licenses apply:
- *
- * Copyright (C) 2024 Sky
+/**
+ * Copyright 2024 Comcast Cable Communications Management, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,6 +12,8 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 /** @brief

--- a/example/FWManager/service/FWManager.h
+++ b/example/FWManager/service/FWManager.h
@@ -1,8 +1,5 @@
-/*
- * If not stated otherwise in this file or this component's LICENSE file the
- * following copyright and licenses apply:
- *
- * Copyright (C) 2024 Sky
+/**
+ * Copyright 2024 Comcast Cable Communications Management, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,6 +12,8 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 /** @brief

--- a/example/FWManager/service/FWManagerService.cpp
+++ b/example/FWManager/service/FWManagerService.cpp
@@ -1,8 +1,5 @@
-/*
- * If not stated otherwise in this file or this component's LICENSE file the
- * following copyright and licenses apply:
- *
- * Copyright (C) 2024 Sky
+/**
+ * Copyright 2024 Comcast Cable Communications Management, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,6 +12,8 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 /** @brief

--- a/liblog/CMakeLists.txt
+++ b/liblog/CMakeLists.txt
@@ -1,8 +1,5 @@
-# *
-# * If not stated otherwise in this file or this component's LICENSE file the
-# * following copyright and licenses apply:
-# *
-# * Copyright (C) 2024 Sky
+#/**
+# * Copyright 2024 Comcast Cable Communications Management, LLC
 # *
 # * Licensed under the Apache License, Version 2.0 (the "License");
 # * you may not use this file except in compliance with the License.
@@ -16,6 +13,8 @@
 # * See the License for the specific language governing permissions and
 # * limitations under the License.
 # *
+# * SPDX-License-Identifier: Apache-2.0
+# */
 
 # **@brief
 # * The cmake is used to build the Android liblog module.

--- a/patches/aidl.patch
+++ b/patches/aidl.patch
@@ -1,7 +1,7 @@
 #####################################################################
 Date: Thu Nov 2 17:53:48 2023 +0100
 From: dc1275ca875479c6d1467e018d27e6a41c7d4069 Thu Apr 28 05:46:25 2022
-Source: Sky
+Source: Comcast
 Subject: Fix the compilation issues in the Linux environment
 #####################################################################
 

--- a/patches/core.patch
+++ b/patches/core.patch
@@ -1,7 +1,7 @@
 #####################################################################
 Date: Thu Nov 2 16:17:28 2023 +0100
 From: 8301b33dad51cafd9d08876fc91a7e5fa556dcd3 Fri Mar 24 15:59:07 2023
-Source: Sky & Android OpenSource Project
+Source: Comcast & Android OpenSource Project
 Subject: Fix the compilation issues in the Linux environment
 #####################################################################
 diff --git a/libcutils/ashmem-host.cpp b/libcutils/ashmem-host.cpp

--- a/patches/libbase.patch
+++ b/patches/libbase.patch
@@ -1,7 +1,7 @@
 #####################################################################
 Date: Thu Nov 2 15:45:32 2023 +0100
 From: 8436e04cfaa6c21be86b37e9599184d77c67faef Wed May 25 18:41:55 2022
-Source: Sky
+Source: Comcast
 Subject: Fix the compilation issues in the Linux environment
 #####################################################################
 diff --git a/logging.cpp b/logging.cpp

--- a/patches/logging.patch
+++ b/patches/logging.patch
@@ -1,7 +1,7 @@
 #####################################################################
 Date: Thu Nov 2 11:23:41 2023 +0100
 From: ec3daa6f52131c87da38e1c7be6b374e3ccf6e0d Thu Jan 26 02:19:15
-Source: Sky & Android OpenSource Project
+Source: Comcast & Android OpenSource Project
 Subject: Fix the compilation issues in the Linux environment
 #####################################################################
 diff --git a/liblog/include/cutils/list.h b/liblog/include/cutils/list.h

--- a/patches/native.patch
+++ b/patches/native.patch
@@ -1,7 +1,7 @@
 #####################################################################
 Date: Thu Nov 2 13:57:44 2023 +0100
 From: ee3935f4c64d58f9f87ff6fac875cdad42f46038 Tue May 09 04:05:45 2023
-Source: Sky & Android OpenSource Project
+Source: Comcast & Android OpenSource Project
 Subject: Fix the compilation issues in the Linux environment
 #####################################################################
 diff --git a/cmds/servicemanager/Access.cpp b/cmds/servicemanager/Access.cpp

--- a/setup-env.sh
+++ b/setup-env.sh
@@ -1,10 +1,7 @@
 #!/bin/sh
 
-# *
-# * If not stated otherwise in this file or this component's LICENSE file the
-# * following copyright and licenses apply:
-# *
-# * Copyright (C) 2024 Sky
+#/**
+# * Copyright 2024 Comcast Cable Communications Management, LLC
 # *
 # * Licensed under the Apache License, Version 2.0 (the "License");
 # * you may not use this file except in compliance with the License.
@@ -18,6 +15,8 @@
 # * See the License for the specific language governing permissions and
 # * limitations under the License.
 # *
+# * SPDX-License-Identifier: Apache-2.0
+# */
 
 # ** @brief: Build linux binder idl module.
 # *          This is basically to build the binder and example modules for host machine.

--- a/tools/BinderDevice.c
+++ b/tools/BinderDevice.c
@@ -1,8 +1,5 @@
-/*
- * If not stated otherwise in this file or this component's LICENSE file the
- * following copyright and licenses apply:
- *
- * Copyright (C) 2024 Sky
+/**
+ * Copyright 2024 Comcast Cable Communications Management, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,6 +12,8 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
  */
 
 /** @brief


### PR DESCRIPTION
 - Updated Copyright in NOTICE and Patch files
 - Updated the headers on source files with the standard Comcast apache header