### PR TITLE
feat: extend FWManager example with ParcelFileDescriptor (#16)

### DIFF
--- a/example/FWManager/aidl/com/test/IFWManager.aidl
+++ b/example/FWManager/aidl/com/test/IFWManager.aidl
@@ -25,6 +25,7 @@
 // IFWManager.aidl
 package com.test;
 
+import android.os.ParcelFileDescriptor;
 import com.test.FirmwareStatus;
 import com.test.IFirmwareUpdateStateListener;
 
@@ -54,4 +55,10 @@ interface IFWManager {
      * Registers a listener for firmware update state changes.
      */
     void registerDeviceStateFirmwareUpdateStateChanged(in IFirmwareUpdateStateListener listener) = 404;
+
+    /*
+     * Gets a file descriptor for reading the firmware update log.
+     * Demonstrates ParcelFileDescriptor as a built-in AIDL type.
+     */
+    ParcelFileDescriptor getFirmwareLogFile() = 405;
 }

--- a/example/FWManager/service/FWManager.cpp
+++ b/example/FWManager/service/FWManager.cpp
@@ -22,6 +22,8 @@
  * Contains the implementation of the FWManager interfaces.
  */
 
+#include <cerrno>
+#include <cstring>
 #include <string>
 #include <iostream>
 #include <fstream>
@@ -116,10 +118,10 @@ Status FWManager::registerDeviceStateFirmwareUpdateStateChanged(const sp<IFirmwa
 Status FWManager::getFirmwareLogFile(::android::os::ParcelFileDescriptor* _aidl_return) {
     const char* logPath = "/tmp/fw_update.log";
 
-    int fd = open(logPath, O_RDONLY | O_CREAT, 0644);
+    int fd = open(logPath, O_RDONLY | O_CREAT | O_NOFOLLOW | O_CLOEXEC, 0644);
     if (fd < 0) {
-        printf("\nFWManager : Failed to open firmware log file: %s\n", logPath);
-        return Status::fromServiceSpecificError(-1, String8("Failed to open log file"));
+        printf("\nFWManager : Failed to open firmware log file: %s (%s)\n", logPath, strerror(errno));
+        return Status::fromServiceSpecificError(-errno, String8("Failed to open log file"));
     }
 
     printf("\nFWManager : Returning firmware log fd=%d for %s\n", fd, logPath);

--- a/example/FWManager/service/FWManager.cpp
+++ b/example/FWManager/service/FWManager.cpp
@@ -25,9 +25,12 @@
 #include <string>
 #include <iostream>
 #include <fstream>
+#include <fcntl.h>
 #include <sys/stat.h>
 #include <unistd.h>
 #include <sys/reboot.h>
+
+#include <android-base/unique_fd.h>
 
 #include <binder/IServiceManager.h>
 #include <utils/StrongPointer.h>
@@ -102,6 +105,25 @@ Status FWManager::registerDeviceStateFirmwareUpdateStateChanged(const sp<IFirmwa
     printf("\nFWManager : Register IFirmwareUpdateStateListener\n");
     std::thread threadStartFirmwareUpdate(startFirmwareUpdatethread, listener);
     threadStartFirmwareUpdate.detach();
+
+    return Status::ok();
+}
+
+/*
+ * Gets a file descriptor for reading the firmware update log.
+ * Opens /tmp/fw_update.log (or creates it) and returns the fd to the caller.
+ */
+Status FWManager::getFirmwareLogFile(::android::os::ParcelFileDescriptor* _aidl_return) {
+    const char* logPath = "/tmp/fw_update.log";
+
+    int fd = open(logPath, O_RDONLY | O_CREAT, 0644);
+    if (fd < 0) {
+        printf("\nFWManager : Failed to open firmware log file: %s\n", logPath);
+        return Status::fromServiceSpecificError(-1, String8("Failed to open log file"));
+    }
+
+    printf("\nFWManager : Returning firmware log fd=%d for %s\n", fd, logPath);
+    _aidl_return->reset(android::base::unique_fd(fd));
 
     return Status::ok();
 }

--- a/example/FWManager/service/FWManager.h
+++ b/example/FWManager/service/FWManager.h
@@ -34,6 +34,7 @@
 
 #include <android/log.h>
 #include <binder/BinderService.h>
+#include <binder/ParcelFileDescriptor.h>
 #include <binder/Status.h>
 #include <utils/Errors.h>
 #include <utils/Log.h>
@@ -100,6 +101,11 @@ class FWManager : public android::BinderService<FWManager>,
          * Registers a listener for firmware update state changes.
          */
         Status registerDeviceStateFirmwareUpdateStateChanged(const sp<IFirmwareUpdateStateListener>& listener) override;
+
+        /*
+         * Gets a file descriptor for reading the firmware update log.
+         */
+        Status getFirmwareLogFile(::android::os::ParcelFileDescriptor* _aidl_return) override;
 };
 
 #endif //_FW_MANAGER_H_


### PR DESCRIPTION
## Summary

- Add `import android.os.ParcelFileDescriptor` to `IFWManager.aidl`
- Add `getFirmwareLogFile()` method returning a `ParcelFileDescriptor` for the firmware update log
- Implement the method in `FWManager.h` / `FWManager.cpp` (opens `/tmp/fw_update.log` and returns the fd)

Demonstrates that `ParcelFileDescriptor` works end-to-end in the C++ binder framework:
1. AIDL compiler recognises it as a built-in type (`aidl_typenames.cpp:59`)
2. C++ backend generates correct `::android::os::ParcelFileDescriptor` signature (`aidl_to_cpp.cpp:175`)
3. Links against `libbinder.so` which contains the `ParcelFileDescriptor` implementation

Verified: `generate_cpp.sh` + `build-binder-example.sh` produce `FWManagerService`, `FWManagerClient`, and `libfwmanager.so` with no errors.

Closes #16

## Test plan

- [ ] Run `./example/generate_cpp.sh --clean` — verify AIDL generation succeeds
- [ ] Run `./build-binder-example.sh --force` — verify build completes (100%)
- [ ] Inspect generated `IFWManager.h` — confirm `getFirmwareLogFile(::android::os::ParcelFileDescriptor*)` signature
- [ ] Optionally run `FWManagerService` + `FWManagerClient` on a binder-capable system