### PR TITLE
fix(build): always regenerate C++ from AIDL on build (rdk-halif-aidl#530)

### DIFF
--- a/host/CMakeLists.inc
+++ b/host/CMakeLists.inc
@@ -169,7 +169,9 @@ function(AddInterfaceLibrary aidl_target)
         set(interface_version "current")
         set(interface_version_arg "")
     else()
-        set(interface_version_arg "-v ${interface_version}")
+        # CMake list so execute_process expands this to two separate argv entries.
+        # aidl_ops.py uses getopt and rejects "-v <version>" as a single token.
+        set(interface_version_arg -v ${interface_version})
     endif()
 
     if (NOT "${${aidl_target}_deps}" STREQUAL "")
@@ -202,7 +204,12 @@ function(AddInterfaceLibrary aidl_target)
     #     compile and eliminates the "ship stale generated code" class of
     #     bug entirely.
     #   - Frozen versions (e.g. v1, v2): pre-committed C++ is part of the
-    #     release contract - never regenerate; reuse what's on disk.
+    #     release contract - if pre-committed sources exist on disk, reuse
+    #     them as-is and skip regen entirely. The first build of a freshly
+    #     checked-out frozen version that ships no generated tree (rare,
+    #     but possible for in-flight versions before sources are committed)
+    #     will generate once to bootstrap; subsequent builds reuse what's
+    #     on disk.
     file(GLOB_RECURSE existing_sources "${source_dir}/*.cpp")
 
     if (interface_version STREQUAL "current")
@@ -216,7 +223,7 @@ function(AddInterfaceLibrary aidl_target)
         )
 
         if(NOT gen_result EQUAL 0)
-            message(FATAL_ERROR "Failed to generate sources for ${interface_name}. Run './build_interfaces.sh ${interface_name}' first.")
+            message(FATAL_ERROR "AIDL generation failed for ${interface_name}; check the aidl_ops.py output above.")
         endif()
 
         # Re-glob after generation; the generator writes <module>/current/{src,include}.
@@ -251,7 +258,7 @@ function(AddInterfaceLibrary aidl_target)
         )
 
         if(NOT gen_result EQUAL 0)
-            message(FATAL_ERROR "Failed to generate sources for ${interface_name}. Run './build_interfaces.sh ${interface_name}' first.")
+            message(FATAL_ERROR "AIDL generation failed for ${interface_name}; check the aidl_ops.py output above.")
         endif()
 
         # Re-check after generation

--- a/host/CMakeLists.inc
+++ b/host/CMakeLists.inc
@@ -190,25 +190,70 @@ function(AddInterfaceLibrary aidl_target)
     set(source_dir ${LINUX_BINDER_AIDL_GENERATED_ROOT}/${interface_name}/${interface_version}/src)
     set(include_dir ${LINUX_BINDER_AIDL_GENERATED_ROOT}/${interface_name}/${interface_version}/include)
 
-    # Check if generated sources already exist (pre-committed in repo)
+    # Regeneration policy (#530, Option A):
+    #   - "current" version: ALWAYS regenerate. The AIDL under <module>/current/
+    #     is mutable and the previous "skip if include/src already populated"
+    #     guard silently shipped stale C++ when the AIDL changed but the
+    #     generated tree happened to exist (e.g. from a prior build or a
+    #     stale checkout). The AIDL compiler overwrites in place, so a
+    #     successful regen brings the tree to byte-equivalent state with
+    #     the AIDL; if a method or type is removed, its primary file is
+    #     overwritten with the new content. Regen is cheap relative to
+    #     compile and eliminates the "ship stale generated code" class of
+    #     bug entirely.
+    #   - Frozen versions (e.g. v1, v2): pre-committed C++ is part of the
+    #     release contract - never regenerate; reuse what's on disk.
     file(GLOB_RECURSE existing_sources "${source_dir}/*.cpp")
-    
-    if(NOT existing_sources)
-        # Generated code doesn't exist - need to run API update first
-        message(STATUS "No pre-generated sources found for ${interface_name} v${interface_version}")
-        message(STATUS "Generating sources using aidl_ops...")
-        
+
+    if (interface_version STREQUAL "current")
+        message(STATUS "Regenerating sources for ${interface_name} v${interface_version} (always-regen, #530)")
+
         # Generate Sources
         message(VERBOSE "Command: ${LINUX_BINDER_AIDL_ROOT_HOST}/aidl_ops.py -g ${interface_version_arg} -r ${interfaces_dir} -o ${LINUX_BINDER_AIDL_ROOT_OUT} ${interface_name}")
         execute_process(
             COMMAND ${LINUX_BINDER_AIDL_ROOT_HOST}/aidl_ops.py -g ${interface_version_arg} -r "${interfaces_dir}" -o "${LINUX_BINDER_AIDL_ROOT_OUT}" ${interface_name}
             RESULT_VARIABLE gen_result
         )
-        
+
         if(NOT gen_result EQUAL 0)
             message(FATAL_ERROR "Failed to generate sources for ${interface_name}. Run './build_interfaces.sh ${interface_name}' first.")
         endif()
-        
+
+        # Re-glob after generation; the generator writes <module>/current/{src,include}.
+        file(GLOB_RECURSE source_files "${source_dir}/*.cpp")
+        if(NOT source_files)
+            # Defensive fallback: if regen ran cleanly but produced no files in
+            # the expected location (e.g. a component whose interface loader
+            # maps to a different versioned directory than CMake's "current"
+            # path), fall back to any pre-committed sources so the build
+            # remains usable. This preserves the previous behaviour for those
+            # components without losing the new always-regen guarantee for the
+            # common case.
+            if(existing_sources)
+                list(LENGTH existing_sources list_length)
+                message(WARNING "Regeneration produced no files in ${source_dir}; "
+                                "falling back to ${list_length} pre-committed source(s). "
+                                "Generated C++ may be stale relative to AIDL.")
+                set(source_files ${existing_sources})
+            else()
+                message(FATAL_ERROR "Source generation completed but no C++ files found in ${source_dir}")
+            endif()
+        endif()
+    elseif(NOT existing_sources)
+        # Frozen version with no pre-committed sources - generate once.
+        message(STATUS "No pre-generated sources found for ${interface_name} v${interface_version}")
+        message(STATUS "Generating sources using aidl_ops...")
+
+        message(VERBOSE "Command: ${LINUX_BINDER_AIDL_ROOT_HOST}/aidl_ops.py -g ${interface_version_arg} -r ${interfaces_dir} -o ${LINUX_BINDER_AIDL_ROOT_OUT} ${interface_name}")
+        execute_process(
+            COMMAND ${LINUX_BINDER_AIDL_ROOT_HOST}/aidl_ops.py -g ${interface_version_arg} -r "${interfaces_dir}" -o "${LINUX_BINDER_AIDL_ROOT_OUT}" ${interface_name}
+            RESULT_VARIABLE gen_result
+        )
+
+        if(NOT gen_result EQUAL 0)
+            message(FATAL_ERROR "Failed to generate sources for ${interface_name}. Run './build_interfaces.sh ${interface_name}' first.")
+        endif()
+
         # Re-check after generation
         file(GLOB_RECURSE source_files "${source_dir}/*.cpp")
         if(NOT source_files)

--- a/host/aidl_interface.py
+++ b/host/aidl_interface.py
@@ -176,6 +176,18 @@ def load_interfaces(interfaces_roots, out_dir, gen_dir=None, gen_lib_deps=False)
                 interface_locations.append(path.join(root, INTERFACE_DEF_YAML))
 
     logger.debug("Interfaces found at %s" %(interface_locations))
+    # Stable ordering: walk order from os.walk is filesystem-dependent, but
+    # when a module ships both <module>/current/interface.yaml AND a frozen
+    # snapshot <module>/<x.y.z>/interface.yaml under the same base_name,
+    # the LAST one inserted into the aidl_interfaces dict wins - which
+    # decides where the generator writes its output. Sort with frozen
+    # versions first and "current" last so current always wins, matching
+    # the "build current" intent of the rest of the toolchain (#530).
+    def _interface_sort_key(loc):
+        parent = path.basename(path.dirname(loc))
+        # "current" sorts last; everything else by name
+        return (1 if parent == "current" else 0, parent, loc)
+    interface_locations.sort(key=_interface_sort_key)
     aidl_interfaces = {}
     for interface_loc in interface_locations:
         aidl_interface = AidlInterface(interfaces_roots, path.dirname(interface_loc),


### PR DESCRIPTION
## Summary

Fixes [rdkcentral/rdk-halif-aidl#530](https://github.com/rdkcentral/rdk-halif-aidl/issues/530) — the AIDL→C++ regeneration step in `host/CMakeLists.inc` was silently skipped whenever `<module>/current/include/` and `<module>/current/src/` already contained generated artefacts, even when the source AIDL had changed. Contributors would edit AIDL, see *"Build completed successfully"*, and ship PRs whose committed generated C++ did NOT match the AIDL they had actually changed. This bit the rdk-halif-aidl team at least four times in a single session on `#492`-area rebases; every regen agent had to manually `rm -rf <component>/current/include <component>/current/src` before running `./build_modules.sh <comp>` to defeat the guard.

This PR implements **Option A** from the upstream issue (chosen by the project owner): always regenerate on every build for `interface_version == "current"`. The AIDL compiler overwrites files in place, so the cost is negligible (a few hundred ms of `aidl` runs in `execute_process` per configure) and the previously silent class of *"shipped stale generated C++"* bugs disappears entirely.

### Changes

- **`host/CMakeLists.inc`** — `AddInterfaceLibrary()`:
  - For `current`, always invoke `aidl_ops.py -g`. The previous `if(NOT existing_sources)` guard is removed for this branch.
  - For frozen versions (e.g. `0.1.0.0`), keep the existing skip-if-pre-committed behaviour. Released snapshots are part of the API contract and must remain immutable.
  - Defensive fallback when regen produces no files in the expected `source_dir` (e.g. a component whose loader maps to a different versioned directory): warn and reuse pre-committed sources instead of failing the build outright.
- **`host/aidl_interface.py`** — `load_interfaces()`:
  - Stable-sort discovered `interface.yaml` locations so `<module>/current/interface.yaml` is always inserted **last** into the `aidl_interfaces` dict. `os.walk` order is filesystem-dependent, and without this sort some components (observed on `audiomixer/0.1.0.1` and `compositeinput/0.2.0.0` in the rdk-halif-aidl tree) ended up with the loader pointing at a frozen snapshot's yaml — causing the new always-regen to write into the snapshot directory and dirty the working tree. With the sort, `current` always wins, matching the *"generate current"* intent of the rest of the toolchain.

### Why two files

The CMake change alone satisfies the rdk-halif-aidl#530 reproducer (avclock single-module build). The Python loader change is a small companion fix that prevents the always-regen from accidentally clobbering pre-released snapshot directories when `./build_modules.sh all` runs — without it, `audiomixer/0.1.0.1/include/**/Bp*.h` and `compositeinput/0.2.0.0/include/**/Bp*.h` end up modified after every full build, which violates rdk-halif-aidl#530's *"existing 21 framework components still build clean"* acceptance. The two changes are tightly coupled; splitting them across PRs would leave a half-broken intermediate state.

## Base branch rationale

This PR targets `feature/19-module-local-generated-output` rather than `develop`. `develop` does not yet contain the module-local layout infrastructure (`bb20fed feat: support module-local generated C++ output` etc.) that this fix builds on, so the fix wouldn't apply cleanly there. `feature/19-module-local-generated-output` is the branch that `rdkcentral/rdk-halif-aidl`'s `binder_sdk.version` is pinned against (`b3b6d69`), so this is the correct integration target.

## Test plan

- [x] **Reproducer (rdk-halif-aidl#530 AC)**: from a clean `rdk-halif-aidl` checkout symlinked against this branch, added a probe method to `avclock/current/com/rdk/hal/avclock/IAVClock.aidl`, ran `./build_modules.sh avclock`, confirmed `git diff avclock/current/include/com/rdk/hal/avclock/IAVClock.h` shows the new `probeAlwaysRegenForIssue530` method in both `IAVClock` and `IAVClockDefault`. Reverted the AIDL edit, re-ran the build, working tree returned to clean.
- [x] **Full build clean**: `./build_modules.sh all` exits with `Build completed successfully!`, 26 libraries built (23 vcurrent + 3 frozen-version companion libs), `git status` shows no modifications to any snapshot directory.
- [x] **No frozen-version regressions**: snapshot `0.1.0.0` / `0.1.0.1` / `0.2.0.0` directories are untouched after a full build (verified via `git status --porcelain`).
- [ ] **Cross-check before merge**: needs a clean-room CI run on a checkout that has never built before, to confirm first-time-generation paths still work.

## Follow-up

A companion PR on `rdkcentral/rdk-halif-aidl` will bump `binder_sdk.version` to this fix's merge commit once it lands.