### PR TITLE
feat(aidl-gen): emit explicit interface version ordinal for module-local snapshots

### DIFF
--- a/host/aidl_gen_rule.py
+++ b/host/aidl_gen_rule.py
@@ -172,6 +172,36 @@ def check_for_sources(dir_path):
 
     return has_content
 
+def resolve_emit_version(layout, module_version, gen_version, hash_gen, base_name):
+    """Resolve the interface VERSION emitted to aidl (the --version value).
+
+    A module-local snapshot may pin an explicit monotonic ordinal via
+    interface.yaml `version:` so a frozen release reports a real
+    getInterfaceVersion() instead of always 1. It is emitted only on a frozen
+    contract (a real `.hash`). When unset — or for non-module-local layouts —
+    the emitted version is gen_version (the resolution version), preserving
+    existing current/ behaviour. This is DECOUPLED from gen_version, which keys
+    import/dependency resolution. (#32)
+
+    Raises RuntimeError if `version:` is not a positive integer, or is set while
+    the contract is still 'notfrozen' (a pinned version needs a frozen .hash).
+    """
+    if layout != "module-local" or module_version is None:
+        return gen_version
+    mv_str = str(module_version).strip()
+    # Positive integer only (also keeps the shell=True interpolation downstream
+    # injection-safe).
+    if not mv_str.isdigit() or int(mv_str) < 1:
+        raise RuntimeError(
+            "interface.yaml 'version' for %s must be a positive integer (got %r)"
+            % (base_name, module_version))
+    if hash_gen == "notfrozen":
+        raise RuntimeError(
+            "interface.yaml 'version: %s' set on %s but the contract is "
+            "'notfrozen' — a pinned version requires a frozen .hash"
+            % (mv_str, base_name))
+    return mv_str
+
 def gen_cpp_sources(interface_name,
         interfaces,
         out_dir,
@@ -279,25 +309,9 @@ def gen_cpp_sources(interface_name,
     # explicit `version:` is only set on a frozen snapshot (real `.hash`); for
     # current/ it is unset, so emit_version == gen_version and HASH == notfrozen,
     # preserving existing behaviour. (#32)
-    emit_version = gen_version
-    mv = getattr(interface, "module_version", None)
-    if interface.layout == "module-local" and mv is not None:
-        mv_str = str(mv).strip()
-        # Validate: positive integer only (also makes the shell=True
-        # interpolation below injection-safe).
-        if not mv_str.isdigit() or int(mv_str) < 1:
-            raise RuntimeError(
-                "interface.yaml 'version' for %s must be a positive integer (got %r)"
-                % (interface.base_name, mv))
-        # Enforce the invariant: a pinned interface version is only meaningful on
-        # a frozen contract. Setting it without a real .hash is a configuration
-        # error, not a silent fallback.
-        if hash_gen == "notfrozen":
-            raise RuntimeError(
-                "interface.yaml 'version: %s' set on %s but the contract is "
-                "'notfrozen' — a pinned version requires a frozen .hash"
-                % (mv_str, interface.base_name))
-        emit_version = mv_str
+    emit_version = resolve_emit_version(
+        interface.layout, getattr(interface, "module_version", None),
+        gen_version, hash_gen, interface.base_name)
 
     # include version and hash
     aidl_gen_cmd = aidl_gen_cmd + \

--- a/host/aidl_gen_rule.py
+++ b/host/aidl_gen_rule.py
@@ -280,8 +280,24 @@ def gen_cpp_sources(interface_name,
     # current/ it is unset, so emit_version == gen_version and HASH == notfrozen,
     # preserving existing behaviour. (#32)
     emit_version = gen_version
-    if interface.layout == "module-local" and getattr(interface, "module_version", None):
-        emit_version = str(interface.module_version)
+    mv = getattr(interface, "module_version", None)
+    if interface.layout == "module-local" and mv is not None:
+        mv_str = str(mv).strip()
+        # Validate: positive integer only (also makes the shell=True
+        # interpolation below injection-safe).
+        if not mv_str.isdigit() or int(mv_str) < 1:
+            raise RuntimeError(
+                "interface.yaml 'version' for %s must be a positive integer (got %r)"
+                % (interface.base_name, mv))
+        # Enforce the invariant: a pinned interface version is only meaningful on
+        # a frozen contract. Setting it without a real .hash is a configuration
+        # error, not a silent fallback.
+        if hash_gen == "notfrozen":
+            raise RuntimeError(
+                "interface.yaml 'version: %s' set on %s but the contract is "
+                "'notfrozen' — a pinned version requires a frozen .hash"
+                % (mv_str, interface.base_name))
+        emit_version = mv_str
 
     # include version and hash
     aidl_gen_cmd = aidl_gen_cmd + \

--- a/host/aidl_gen_rule.py
+++ b/host/aidl_gen_rule.py
@@ -271,9 +271,21 @@ def gen_cpp_sources(interface_name,
         with open(api_dump.hash_file, 'r') as file:
             hash_gen = file.read().replace('\n', '')
 
+    # Emitted interface VERSION / getInterfaceVersion(). A module-local snapshot
+    # may declare an explicit monotonic ordinal (interface.yaml `version:`) so a
+    # frozen release reports a real version instead of always 1. This is
+    # DECOUPLED from gen_version, which keys import/dependency resolution
+    # (get_imports) and must stay at the resolution version. Invariant: an
+    # explicit `version:` is only set on a frozen snapshot (real `.hash`); for
+    # current/ it is unset, so emit_version == gen_version and HASH == notfrozen,
+    # preserving existing behaviour. (#32)
+    emit_version = gen_version
+    if interface.layout == "module-local" and getattr(interface, "module_version", None):
+        emit_version = str(interface.module_version)
+
     # include version and hash
     aidl_gen_cmd = aidl_gen_cmd + \
-            "--version=%s --hash=%s " %(gen_version, hash_gen)
+            "--version=%s --hash=%s " %(emit_version, hash_gen)
 
     aidl_gen_cmd = aidl_gen_cmd + \
             "--out=%s %s " %(gen_dir, " ".join(api_dump.files))

--- a/host/aidl_interface.py
+++ b/host/aidl_interface.py
@@ -1151,6 +1151,11 @@ class AidlInterface:
                             % (self.base_name, name, name, name))
 
         self.stability = data.get("aidl_interface").get("stability")
+        # Optional monotonic interface-version ordinal for module-local layout.
+        # When set (e.g. by release.sh when freezing a snapshot) it drives the
+        # emitted AIDL VERSION / getInterfaceVersion(); absent it defaults to the
+        # usual next_version() (1), preserving existing behaviour. (#32)
+        self.module_version = data.get("aidl_interface").get("version")
         versions = []
         versions_with_info = {}
         ver_info = data.get("aidl_interface").get("versions_with_info")

--- a/host/aidl_interface.py
+++ b/host/aidl_interface.py
@@ -1151,10 +1151,10 @@ class AidlInterface:
                             % (self.base_name, name, name, name))
 
         self.stability = data.get("aidl_interface").get("stability")
-        # Optional monotonic interface-version ordinal for module-local layout.
-        # When set (e.g. by release.sh when freezing a snapshot) it drives the
-        # emitted AIDL VERSION / getInterfaceVersion(); absent it defaults to the
-        # usual next_version() (1), preserving existing behaviour. (#32)
+        # Optional explicit interface-version for module-local layout. When set
+        # (e.g. by release.sh when freezing a snapshot) it drives the emitted
+        # AIDL VERSION / getInterfaceVersion(); when absent, the emitted version
+        # falls back to the usual next_version(), preserving existing behaviour. (#32)
         self.module_version = data.get("aidl_interface").get("version")
         versions = []
         versions_with_info = {}

--- a/tests/test_interface_version_ordinal.py
+++ b/tests/test_interface_version_ordinal.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+#/**
+# * Copyright 2026 RDK Management
+# *
+# * Licensed under the Apache License, Version 2.0 (the "License");
+# * you may not use this file except in compliance with the License.
+# * You may obtain a copy of the License at
+# *
+# * http://www.apache.org/licenses/LICENSE-2.0
+# *
+# * Unless required by applicable law or agreed to in writing, software
+# * distributed under the License is distributed on an "AS IS" BASIS,
+# * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# * See the License for the specific language governing permissions and
+# * limitations under the License.
+# *
+# * SPDX-License-Identifier: Apache-2.0
+# */
+#
+# Regression test for issue #32 — module-local snapshots must emit a real
+# interface VERSION ordinal (getInterfaceVersion()), not always 1.
+#
+# Exercises aidl_gen_rule.resolve_emit_version directly, asserting:
+#   - a frozen module-local snapshot with `version: N` emits N (not gen_version),
+#   - an unset version, or a non-module-local layout, falls back to gen_version
+#     (preserving current/ behaviour),
+#   - a pinned version on a 'notfrozen' contract is rejected,
+#   - a non-positive / non-integer version is rejected.
+#
+# Run: python3 tests/test_interface_version_ordinal.py   (exit 0 = pass)
+
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "host"))
+import aidl_gen_rule  # noqa: E402
+
+R = aidl_gen_rule.resolve_emit_version
+FROZEN = "ab12cd34"          # a real contract hash
+GEN = "1"                    # resolution version (the historical emit value)
+
+
+class ResolveEmitVersion(unittest.TestCase):
+    def test_frozen_snapshot_emits_ordinal(self):
+        self.assertEqual(R("module-local", "2", GEN, FROZEN, "IFoo"), "2")
+        self.assertEqual(R("module-local", 20000, GEN, FROZEN, "IFoo"), "20000")
+
+    def test_unset_version_falls_back_to_gen_version(self):
+        self.assertEqual(R("module-local", None, GEN, FROZEN, "IFoo"), GEN)
+
+    def test_non_module_local_ignores_version(self):
+        # Even with a version set, a non-module-local layout keeps gen_version.
+        self.assertEqual(R("global", "2", GEN, FROZEN, "IFoo"), GEN)
+
+    def test_pinned_version_requires_frozen_hash(self):
+        with self.assertRaises(RuntimeError):
+            R("module-local", "2", GEN, "notfrozen", "IFoo")
+
+    def test_rejects_non_positive_or_non_integer(self):
+        for bad in ("0", "-1", "x", "1.0", ""):
+            with self.assertRaises(RuntimeError):
+                R("module-local", bad, GEN, FROZEN, "IFoo")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
Refs #32

## What
Adds an optional `version:` ordinal to module-local `interface.yaml`. When present, it drives the emitted AIDL `VERSION` / `getInterfaceVersion()` (via the aidl `--version` flag), so a **frozen** snapshot can report a real monotonic version instead of always `1`. Combined with the existing `.hash` wiring (`--hash`), `getInterfaceHash()` then returns the real contract SHA instead of `notfrozen`.

## Key design point
The emitted version is **decoupled** from `gen_version`. `gen_version` keys import/dependency resolution (`get_imports`/`get_dependencies`) and must remain the resolution version — overriding it directly breaks dep resolution (`AssertionError: Unknown version provided`). So a separate `emit_version` feeds only the `--version` flag.

## Backward compatibility
No interface declares `version:` today, so `emit_version == gen_version` and `HASH == notfrozen` — output is byte-identical. Verified by regenerating a `current` module (`VERSION = 1`, builds clean).

**Invariant** the consumer must uphold: `version:` is only set on a **frozen** snapshot (one with a real `.hash`); `current/` leaves it unset. (Avoids the contradictory `--version=N --hash=notfrozen`.)

## Follow-on (consumer repo: rdk-halif-aidl)
`release.sh` sets `version:` on each snapshot and regenerates it against its own `.hash` at freeze time, plus a SHA→`X.Y.Z.W` manifest. Tracked there.

Not CI-verified beyond backward-compat regeneration — the frozen end-to-end path is validated when the release-side wiring lands.