### PR TITLE
fix(toolchain): use get_filename_component instead of file(REAL_PATH) for CMake 3.8 compatibility

### DIFF
--- a/host/CMakeLists.inc
+++ b/host/CMakeLists.inc
@@ -100,7 +100,7 @@ execute_process(COMMAND pwd OUTPUT_VARIABLE WORKING_DIR OUTPUT_STRIP_TRAILING_WH
 message(STATUS "WORKING_DIR: ${WORKING_DIR} ")
 if (DEFINED INTERFACES_ROOT_DIRS)
     foreach(interface_dir IN LISTS INTERFACES_ROOT_DIRS)
-        file(REAL_PATH ${interface_dir} interface_dir_abs BASE_DIRECTORY ${WORKING_DIR})
+        get_filename_component(interface_dir_abs "${interface_dir}" REALPATH BASE_DIR "${WORKING_DIR}")
         list(APPEND interfaces_dir ${interface_dir_abs})
     endforeach()
 else()

--- a/tests/test_cmake_min_version_compat.sh
+++ b/tests/test_cmake_min_version_compat.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+
+#/**
+# * Copyright 2026 RDK Management
+# *
+# * Licensed under the Apache License, Version 2.0 (the "License");
+# * you may not use this file except in compliance with the License.
+# * You may obtain a copy of the License at
+# *
+# * http://www.apache.org/licenses/LICENSE-2.0
+# *
+# * Unless required by applicable law or agreed to in writing, software
+# * distributed under the License is distributed on an "AS IS" BASIS,
+# * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# * See the License for the specific language governing permissions and
+# * limitations under the License.
+# *
+# * SPDX-License-Identifier: Apache-2.0
+# */
+#
+# Regression test for issue #24 — the build declares
+# `cmake_minimum_required(VERSION 3.8)` but used `file(REAL_PATH ...)`, a
+# sub-command added in CMake 3.19. On a 3.8–3.18 CMake the configure dies with
+# "file does not recognize sub-command REAL_PATH". The fix uses
+# `get_filename_component(... REALPATH ...)` (available since 2.x).
+#
+# This guard scans every CMake file for sub-commands newer than the declared
+# `cmake_minimum_required`, so a regression that reintroduces a too-new command
+# is caught without needing an old CMake to hand. Currently checks `file()`
+# sub-commands introduced after 3.8 (REAL_PATH @3.19, others as listed).
+set -uo pipefail
+
+HERE="$(cd "$(dirname "$(realpath "${BASH_SOURCE[0]}")")" && pwd)"
+ROOT="$(cd "${HERE}/.." && pwd)"
+
+pass() { echo "  PASS  $1"; }
+fail() { echo "  FAIL  $1"; exit 1; }
+
+# file() sub-commands that require CMake newer than the declared 3.8 floor.
+# (extend as needed)
+#   REAL_PATH      3.19
+#   ARCHIVE_*      3.18
+#   CONFIGURE      3.18
+PATTERN='file *\( *(REAL_PATH|ARCHIVE_CREATE|ARCHIVE_EXTRACT|CONFIGURE)\b'
+
+mapfile -t CMAKE_FILES < <(find "${ROOT}" \
+    \( -name 'CMakeLists.txt' -o -name '*.cmake' -o -name '*.inc' \) \
+    -not -path '*/.git/*' -not -path '*/output*/*' -not -path '*/.buildroot/*' 2>/dev/null | sort)
+
+[ "${#CMAKE_FILES[@]}" -gt 0 ] || fail "no CMake files found (unexpected)"
+
+hits="$(grep -EnH "${PATTERN}" "${CMAKE_FILES[@]}" 2>/dev/null || true)"
+if [ -n "${hits}" ]; then
+    echo "    too-new file() sub-command(s) vs declared cmake_minimum_required(3.8):"
+    echo "${hits}" | sed 's/^/    /'
+    fail "#24: CMake sub-command newer than the 3.8 floor — breaks configure on CMake 3.8–3.18"
+fi
+pass "#24: no file() sub-command newer than the declared cmake_minimum_required(3.8)"


### PR DESCRIPTION
Fixes #24

## Problem
`host/CMakeLists.inc:103` uses `file(REAL_PATH …)`, which was added in **CMake 3.19**, but every CMake file in the repo declares `cmake_minimum_required(VERSION 3.8)`. On CMake < 3.19 the build fails:

```
CMake Error at build-tools/linux_binder_idl/host/CMakeLists.inc:103 (file):
  file does not recognize sub-command REAL_PATH
```

## Fix
Replace the single occurrence with the equivalent, **3.4+-compatible** form:

```cmake
get_filename_component(interface_dir_abs "${interface_dir}" REALPATH BASE_DIR "${WORKING_DIR}")
```

This keeps the declared 3.8 floor (no forced version bump on consumers). It's the only `file(REAL_PATH)` in the repo, and no other 3.19+ commands are used.

## Verification
Behaviour is identical to `file(REAL_PATH … BASE_DIRECTORY …)` — verified with `cmake -P`:
- relative `sub/x` + base `/tmp/base` → `/tmp/base/sub/x`
- absolute `/abs/y` → `/abs/y` (unchanged)