### PR TITLE
fix(binder): restore pre-5.16 freeze fallbacks so 4.9 builds (#35)

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,9 +1,8 @@
 [linux_binder_idl]
 Copyright 2024 Comcast Cable Communications Management, LLC
 Copyright 2026 RDK Management
-Licensed under the Apache License, Version 2.0
 
-Licensed under the Apache License, Version 2.0 (the "License");you may not use this file except in compliance with the License.
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
 http://www.apache.org/licenses/LICENSE-2.0

--- a/NOTICE
+++ b/NOTICE
@@ -1,5 +1,7 @@
 [linux_binder_idl]
 Copyright 2024 Comcast Cable Communications Management, LLC
+Copyright 2026 RDK Management
+Licensed under the Apache License, Version 2.0
 
 Licensed under the Apache License, Version 2.0 (the "License");you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/patches/native.patch
+++ b/patches/native.patch
@@ -513,38 +513,3 @@ index a579442..47fb4c8 100644
  #include <map>
  #include <optional>
  #include <thread>
-diff --git a/libs/binder/binder_module.h b/libs/binder/binder_module.h
-index 793795e..2a9c8ef 100644
---- a/libs/binder/binder_module.h
-+++ b/libs/binder/binder_module.h
-@@ -38,6 +38,12 @@
- #define BR_FROZEN_REPLY _IO('r', 18)
- #endif // BR_FROZEN_REPLY
- 
-+/*
-+ * Skip struct definitions - modern kernel headers already have them.
-+ * These fallback definitions are only for very old kernels (pre-5.16).
-+ * Since we require kernel 5.16+, we don't need these fallback definitions.
-+ */
-+#if 0
- #ifndef BINDER_FREEZE
- /*
-  * Temporary definitions for freeze support. For the final version
-@@ -64,8 +70,6 @@ struct binder_freeze_info {
- #endif // BINDER_FREEZE
- 
- #ifndef BINDER_GET_FROZEN_INFO
--
--#define BINDER_GET_FROZEN_INFO _IOWR('b', 15, struct binder_frozen_status_info)
- 
- struct binder_frozen_status_info {
-     //
-@@ -87,6 +91,8 @@ struct binder_frozen_status_info {
-     __u32 async_recv;
- };
- #endif // BINDER_GET_FROZEN_INFO
-+#endif // #if 0 - Disabled fallback definitions
-+#define BINDER_GET_FROZEN_INFO _IOWR('b', 15, struct binder_frozen_status_info)
- 
- #ifndef BR_ONEWAY_SPAM_SUSPECT
- // Temporary definition of BR_ONEWAY_SPAM_SUSPECT. For production

--- a/tests/test_binder_4_9_fallbacks.sh
+++ b/tests/test_binder_4_9_fallbacks.sh
@@ -71,9 +71,16 @@ else
 fi
 [ -s "${WORK}/libs/binder/binder_module.h" ] || skip "binder_module.h unavailable"
 
-# Apply only the binder_module.h hunk(s) of native.patch.
-( cd "${WORK}" && git init -q && git apply --include='libs/binder/binder_module.h' "${PATCH}" 2>/dev/null ) \
-    || true   # if the patch no longer touches the file (fixed), that's fine
+# Apply only the binder_module.h hunk(s) of native.patch, IF native.patch
+# touches that file. When it does, the apply MUST succeed — otherwise we'd be
+# compiling the unpatched header and could report a false PASS. When it does
+# not (the #35 fix leaves binder_module.h upstream), there is nothing to apply
+# and the upstream fallbacks are already in place.
+command -v git >/dev/null 2>&1 || skip "git not available"
+if grep -q 'b/libs/binder/binder_module.h' "${PATCH}"; then
+    ( cd "${WORK}" && git init -q && git apply --include='libs/binder/binder_module.h' "${PATCH}" ) \
+        || fail "native.patch modifies binder_module.h but its hunk failed to apply"
+fi
 
 # A 4.9-era <linux/android/binder.h>: the base ioctl surface, but NO freeze
 # support (binder_frozen_status_info / BINDER_FREEZE / BINDER_GET_FROZEN_INFO).
@@ -106,7 +113,7 @@ int probe(void) {
 EOF
 
 echo "  compiling against a 4.9-style UAPI header (no freeze support) ..."
-if "${CXX}" -c -I"${WORK}/uapi49" -I"${WORK}" "${WORK}/probe.c" -o "${WORK}/probe.o" 2>"${WORK}/cc.err"; then
+if "${CXX}" -x c++ -c -I"${WORK}/uapi49" -I"${WORK}" "${WORK}/probe.c" -o "${WORK}/probe.o" 2>"${WORK}/cc.err"; then
     pass "#35: binder_module.h freeze fallbacks compile against 4.9 headers"
 else
     echo "    ---- compiler error (fallbacks missing → #35 regression) ----"

--- a/tests/test_binder_4_9_fallbacks.sh
+++ b/tests/test_binder_4_9_fallbacks.sh
@@ -62,12 +62,13 @@ done
 mkdir -p "${WORK}/libs/binder"
 if [ -n "${SRC}" ]; then
     cp "${SRC}/libs/binder/binder_module.h" "${WORK}/libs/binder/binder_module.h"
-elif command -v curl >/dev/null 2>&1 && [ -n "${TAG}" ]; then
+elif command -v curl >/dev/null 2>&1 && command -v base64 >/dev/null 2>&1 && [ -n "${TAG}" ]; then
+    # googlesource ?format=TEXT returns base64, so base64 is required to decode.
     url="https://android.googlesource.com/platform/frameworks/native/+/refs/tags/${TAG}/libs/binder/binder_module.h?format=TEXT"
     curl -fsSL "${url}" 2>/dev/null | base64 -d > "${WORK}/libs/binder/binder_module.h" 2>/dev/null \
         || skip "could not fetch binder_module.h@${TAG}"
 else
-    skip "no AOSP source and no curl to fetch binder_module.h"
+    skip "no AOSP source and no curl+base64 to fetch binder_module.h"
 fi
 [ -s "${WORK}/libs/binder/binder_module.h" ] || skip "binder_module.h unavailable"
 

--- a/tests/test_binder_4_9_fallbacks.sh
+++ b/tests/test_binder_4_9_fallbacks.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+
+#/**
+# * Copyright 2026 RDK Management
+# *
+# * Licensed under the Apache License, Version 2.0 (the "License");
+# * you may not use this file except in compliance with the License.
+# * You may obtain a copy of the License at
+# *
+# * http://www.apache.org/licenses/LICENSE-2.0
+# *
+# * Unless required by applicable law or agreed to in writing, software
+# * distributed under the License is distributed on an "AS IS" BASIS,
+# * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# * See the License for the specific language governing permissions and
+# * limitations under the License.
+# *
+# * SPDX-License-Identifier: Apache-2.0
+# */
+#
+# Regression test for issue #35 — binder must build against OLD kernel UAPI
+# headers (4.9 floor), not just 5.16+.
+#
+# libbinder's binder_module.h carries `#ifndef BINDER_FREEZE` /
+# `#ifndef BINDER_GET_FROZEN_INFO` fallback definitions so it compiles when the
+# kernel's <linux/android/binder.h> predates process-freeze (added ~5.10) — as
+# 4.9 does. A regression disabled those fallbacks (wrapped them in `#if 0` and
+# made BINDER_GET_FROZEN_INFO unconditional) on a "require 5.16+" assumption,
+# which breaks the build against 4.9 headers (undefined struct
+# binder_frozen_status_info / BINDER_FREEZE).
+#
+# This test applies patches/native.patch to the upstream binder_module.h, then
+# compiles a translation unit that exercises the freeze symbols against a
+# 4.9-style UAPI header that intentionally LACKS them. With the fallbacks
+# active it compiles; with them disabled it fails — catching the regression.
+#
+# Skips cleanly (exit 0) when the AOSP source or a compiler is unavailable.
+set -uo pipefail
+
+HERE="$(cd "$(dirname "$(realpath "${BASH_SOURCE[0]}")")" && pwd)"
+ROOT="$(cd "${HERE}/.." && pwd)"
+PATCH="${ROOT}/patches/native.patch"
+CXX="${CXX:-g++}"
+
+skip() { echo "  SKIP  #35 4.9-fallback test — $1"; exit 0; }
+pass() { echo "  PASS  $1"; }
+fail() { echo "  FAIL  $1"; exit 1; }
+
+command -v "${CXX}" >/dev/null 2>&1 || skip "${CXX} not installed"
+[ -f "${PATCH}" ] || skip "patches/native.patch not found"
+
+WORK="$(mktemp -d "${TMPDIR:-/tmp}/binder49.XXXXXX")"
+trap 'rm -rf "${WORK}"' EXIT
+
+# Obtain the upstream binder_module.h (the patch target). Prefer a local AOSP
+# checkout; otherwise fetch just the one file at the pinned tag.
+TAG="$(grep -oE 'android-[0-9.]+_r[0-9]+' "${ROOT}/clone-android-binder-repo.sh" | head -1)"
+SRC=""
+for c in "${ROOT}/android/frameworks/native" /tmp/aosp-native /tmp/aosp-verify; do
+    [ -f "${c}/libs/binder/binder_module.h" ] && { SRC="${c}"; break; }
+done
+mkdir -p "${WORK}/libs/binder"
+if [ -n "${SRC}" ]; then
+    cp "${SRC}/libs/binder/binder_module.h" "${WORK}/libs/binder/binder_module.h"
+elif command -v curl >/dev/null 2>&1 && [ -n "${TAG}" ]; then
+    url="https://android.googlesource.com/platform/frameworks/native/+/refs/tags/${TAG}/libs/binder/binder_module.h?format=TEXT"
+    curl -fsSL "${url}" 2>/dev/null | base64 -d > "${WORK}/libs/binder/binder_module.h" 2>/dev/null \
+        || skip "could not fetch binder_module.h@${TAG}"
+else
+    skip "no AOSP source and no curl to fetch binder_module.h"
+fi
+[ -s "${WORK}/libs/binder/binder_module.h" ] || skip "binder_module.h unavailable"
+
+# Apply only the binder_module.h hunk(s) of native.patch.
+( cd "${WORK}" && git init -q && git apply --include='libs/binder/binder_module.h' "${PATCH}" 2>/dev/null ) \
+    || true   # if the patch no longer touches the file (fixed), that's fine
+
+# A 4.9-era <linux/android/binder.h>: the base ioctl surface, but NO freeze
+# support (binder_frozen_status_info / BINDER_FREEZE / BINDER_GET_FROZEN_INFO).
+mkdir -p "${WORK}/uapi49/linux/android"
+cat > "${WORK}/uapi49/linux/android/binder.h" <<'EOF'
+#ifndef _UAPI_LINUX_BINDER_H_49
+#define _UAPI_LINUX_BINDER_H_49
+#include <linux/types.h>
+#include <linux/ioctl.h>
+/* 4.9-era subset: enough for binder_module.h's non-freeze references.
+ * Deliberately omits BINDER_FREEZE / BINDER_GET_FROZEN_INFO and their structs
+ * so the fallbacks in binder_module.h must supply them. */
+#define BINDER_CURRENT_PROTOCOL_VERSION 8
+struct binder_version { __s32 protocol_version; };
+#define BINDER_VERSION _IOWR('b', 9, struct binder_version)
+#endif
+EOF
+
+# TU exercising the freeze symbols the patched header is responsible for.
+cat > "${WORK}/probe.c" <<'EOF'
+#include <stdint.h>   /* uint32_t used by the freeze fallback structs */
+#include <linux/android/binder.h>
+#include "libs/binder/binder_module.h"
+int probe(void) {
+    struct binder_freeze_info fi = {0};
+    struct binder_frozen_status_info si = {0};
+    (void)fi; (void)si;
+    return (int)(BINDER_FREEZE ^ BINDER_GET_FROZEN_INFO);
+}
+EOF
+
+echo "  compiling against a 4.9-style UAPI header (no freeze support) ..."
+if "${CXX}" -c -I"${WORK}/uapi49" -I"${WORK}" "${WORK}/probe.c" -o "${WORK}/probe.o" 2>"${WORK}/cc.err"; then
+    pass "#35: binder_module.h freeze fallbacks compile against 4.9 headers"
+else
+    echo "    ---- compiler error (fallbacks missing → #35 regression) ----"
+    grep -E 'error:|binder_freeze_info|binder_frozen_status_info|BINDER_FREEZE' "${WORK}/cc.err" | head -8 | sed 's/^/    /'
+    fail "#35: build fails against 4.9 headers — pre-5.16 fallbacks are disabled in binder_module.h"
+fi


### PR DESCRIPTION
Closes #35.

## Problem
`native.patch` disabled `binder_module.h`'s `#ifndef BINDER_FREEZE` / `#ifndef BINDER_GET_FROZEN_INFO` fallback definitions (`#if 0`) and made `BINDER_GET_FROZEN_INFO` unconditional, on a "require kernel 5.16+" assumption. The supported floor is **4.9**. Against 4.9 UAPI headers (no process-freeze) this is a **compile break**: undefined `struct binder_freeze_info` / `binder_frozen_status_info` / `BINDER_FREEZE`.

## Fix
Drop the `binder_module.h` hunk from `native.patch`, restoring the upstream `#ifndef` fallbacks. `binder_module.h` then builds against **both** old (4.9) and new (5.16+) kernel headers. The freeze ioctls stay runtime-guarded, so older kernels degrade gracefully.

## Test
`tests/test_binder_4_9_fallbacks.sh` applies `native.patch` to `binder_module.h` and compiles a freeze-using TU against a **4.9-style UAPI header** (deliberately lacking freeze defs). Passes with the fallbacks active; fails if they're disabled again.

Verified locally: **PASS** with this fix; **FAIL** (reproduces #35: incomplete `binder_freeze_info`/`binder_frozen_status_info`, undefined `BINDER_FREEZE`, `sizeof` incomplete type) against the prior patch. The modified `native.patch` applies cleanly.

## Related
- rdk-halif-aidl#662 (binder runtime / kernel floor); the 4.9 floor is documented in rdk-halif-aidl#663.