### PR TITLE
test: aggregate test-suite runner for tests/ (#37)

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,22 @@
+# Test suite
+
+On-demand regression tests for the binder/AIDL toolchain. These are **tests**,
+not build gates — `build_binder.sh` / `build-aidl-generator-tool.sh` run
+independently; the suite is run separately to catch regressions.
+
+```bash
+./tests/run-tests.sh            # run the whole suite
+./tests/run-tests.sh -k version # only tests matching a substring
+```
+
+`run-tests.sh` auto-discovers every `test_*.sh` / `test_*.py`, so new tests join
+the suite as their PRs merge. Each test prints its own `PASS` / `FAIL` / `SKIP`
+(a SKIP means optional tooling — a compiler, the AOSP source — is absent, and is
+not a failure). The runner exits non-zero if any test fails.
+
+| Test | Guards |
+| --- | --- |
+| `test_yocto_m4_regression.sh` | host AIDL build vs an old sourced `M4` (#30) |
+| `test_binder_4_9_fallbacks.sh` | binder builds against 4.9 kernel UAPI headers (#35) |
+| `test_cmake_min_version_compat.sh` | no CMake sub-command newer than the declared `cmake_minimum_required` (#24) |
+| `test_interface_version_ordinal.py` | module-local snapshots emit the real interface VERSION ordinal (#32) |

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+
+#/**
+# * Copyright 2026 RDK Management
+# *
+# * Licensed under the Apache License, Version 2.0 (the "License");
+# * you may not use this file except in compliance with the License.
+# * You may obtain a copy of the License at
+# *
+# * http://www.apache.org/licenses/LICENSE-2.0
+# *
+# * Unless required by applicable law or agreed to in writing, software
+# * distributed under the License is distributed on an "AS IS" BASIS,
+# * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# * See the License for the specific language governing permissions and
+# * limitations under the License.
+# *
+# * SPDX-License-Identifier: Apache-2.0
+# */
+#
+# Test-suite runner for the linux_binder_idl toolchain. Auto-discovers and runs
+# every tests/test_*.sh and tests/test_*.py, aggregates results, and exits
+# non-zero if any test fails.
+#
+# These are TESTS, run on demand — they do not gate the build (build_binder.sh
+# / build-aidl-generator-tool.sh run independently). A test reports its own
+# PASS/FAIL/SKIP lines; a SKIP (missing optional tooling) is not a failure.
+#
+# Usage:
+#   ./tests/run-tests.sh              # run the whole suite
+#   ./tests/run-tests.sh -k version   # only tests whose name matches 'version'
+set -uo pipefail
+
+HERE="$(cd "$(dirname "$(realpath "${BASH_SOURCE[0]}")")" && pwd)"
+FILTER="${2:-}"
+[ "${1:-}" = "-k" ] || FILTER=""
+
+mapfile -t TESTS < <(find "${HERE}" -maxdepth 1 \( -name 'test_*.sh' -o -name 'test_*.py' \) -type f | sort)
+[ -n "${FILTER}" ] && mapfile -t TESTS < <(printf '%s\n' "${TESTS[@]}" | grep -- "${FILTER}" || true)
+
+echo "========================================="
+echo "  linux_binder_idl test suite"
+echo "  discovered: ${#TESTS[@]} test(s)"
+echo "========================================="
+
+PASS=0; FAIL=0; FAILED_NAMES=()
+for t in "${TESTS[@]}"; do
+    name="$(basename "${t}")"
+    echo ""
+    echo "── ${name} ──"
+    case "${t}" in
+        *.py) runner=(python3 "${t}") ;;
+        *)    runner=(bash "${t}") ;;
+    esac
+    if "${runner[@]}"; then
+        PASS=$((PASS + 1))
+    else
+        FAIL=$((FAIL + 1)); FAILED_NAMES+=("${name}")
+    fi
+done
+
+echo ""
+echo "========================================="
+echo "  suite: ${PASS} passed, ${FAIL} failed (of ${#TESTS[@]})"
+[ "${FAIL}" -gt 0 ] && printf '  failed: %s\n' "${FAILED_NAMES[*]}"
+echo "========================================="
+[ "${FAIL}" -eq 0 ]


### PR DESCRIPTION
Closes #37.

`tests/` had loose regression scripts with no runner — each invoked by hand. Add **`tests/run-tests.sh`**: auto-discovers and runs every `tests/test_*.sh` / `tests/test_*.py`, aggregates `PASS`/`FAIL`/`SKIP`, and exits non-zero on any failure. Plus a `tests/README.md` framing the suite.

These are **tests run on demand**, not build gates — `build_binder.sh` / `build-aidl-generator-tool.sh` run independently. A `SKIP` (missing optional tooling) is not a failure.

Auto-discovery means the incoming regression tests join the suite automatically as their PRs merge:
- `test_binder_4_9_fallbacks.sh` (#35 / PR #36)
- `test_cmake_min_version_compat.sh` (#24 / PR #34)
- `test_interface_version_ordinal.py` (#32 / PR #33)

Validated: the runner discovers and runs the existing `test_yocto_m4_regression.sh` (3/3 checks pass) and reports the suite summary.