### PR TITLE
test(qemu): QEMU kernel-matrix binder round-trip harness (#40)

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -20,3 +20,21 @@ not a failure). The runner exits non-zero if any test fails.
 | `test_binder_4_9_fallbacks.sh` | binder builds against 4.9 kernel UAPI headers (#35) |
 | `test_cmake_min_version_compat.sh` | no CMake sub-command newer than the declared `cmake_minimum_required` (#24) |
 | `test_interface_version_ordinal.py` | module-local snapshots emit the real interface VERSION ordinal (#32) |
+| `test_qemu_binder.sh` → [`qemu/`](qemu/) | binder **round-trip on a real kernel** under QEMU — the runtime gate for the kernel-floor / protocol / bitness work (#35/#36) |
+
+## QEMU binder round-trip (`qemu/`)
+
+`test_qemu_binder.sh` is a thin wrapper for the harness in [`qemu/`](qemu/),
+which boots each target kernel under QEMU and runs a Binder round-trip against
+that kernel's driver — the one thing a Docker/container matrix can't do (containers
+share the host kernel). It builds the binder target libraries + `servicemanager`,
+assembles a small initramfs, and boots the kernel matrix. Heavy and opt-in:
+
+```bash
+./tests/install.sh              # prerequisites (qemu, busybox, cpio, g++, Buildroot deps)
+./tests/qemu/build-kernels.sh   # build the kernel matrix (4.9 floor → 5.16)
+./tests/run-tests.sh -k qemu    # or ./tests/qemu/run-qemu-test.sh
+```
+
+It **skips cleanly** when QEMU/busybox/a compiler or built kernels are absent, so
+it never breaks a default `run-tests.sh`. See [`qemu/README.md`](qemu/README.md).

--- a/tests/install.sh
+++ b/tests/install.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+#/**
+# * Copyright 2026 RDK Management
+# *
+# * Licensed under the Apache License, Version 2.0 (the "License");
+# * you may not use this file except in compliance with the License.
+# * You may obtain a copy of the License at
+# *
+# * http://www.apache.org/licenses/LICENSE-2.0
+# *
+# * Unless required by applicable law or agreed to in writing, software
+# * distributed under the License is distributed on an "AS IS" BASIS,
+# * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# * See the License for the specific language governing permissions and
+# * limitations under the License.
+# *
+# * SPDX-License-Identifier: Apache-2.0
+# */
+#
+# Install the prerequisites for the on-demand test harnesses, in particular the
+# QEMU binder round-trip test (tests/qemu/).
+#
+# Two groups:
+#   RUN   — to run tests/qemu/run-qemu-test.sh: qemu, busybox, cpio, g++, gzip
+#           (timeout/ldd come with coreutils/libc and are normally present).
+#   BUILD — to build the kernel matrix with tests/qemu/build-kernels.sh
+#           (Buildroot): toolchain + wget/tar/rsync/bc/flex/bison/unzip/ncurses/
+#           openssl/elf headers, etc.
+#
+# Usage:
+#   ./tests/install.sh              # install RUN + BUILD prerequisites
+#   ./tests/install.sh --minimal    # RUN prerequisites only (bring your own kernels)
+#   ./tests/install.sh --dry-run    # print the package list, install nothing
+#
+# Supports apt / dnf / pacman. Uses sudo when not root.
+set -euo pipefail
+
+MINIMAL=false
+DRY_RUN=false
+for a in "$@"; do
+    case "$a" in
+        --minimal) MINIMAL=true ;;
+        --dry-run) DRY_RUN=true ;;
+        -h|--help) sed -n '20,33p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'; exit 0 ;;
+        *) echo "Unknown option: $a" >&2; exit 2 ;;
+    esac
+done
+
+# Detect package manager + per-manager package names.
+if   command -v apt-get >/dev/null 2>&1; then PM=apt
+elif command -v dnf     >/dev/null 2>&1; then PM=dnf
+elif command -v pacman  >/dev/null 2>&1; then PM=pacman
+else echo "ERROR: no supported package manager (apt/dnf/pacman) found." >&2; exit 1; fi
+
+case "${PM}" in
+    apt)
+        RUN_PKGS=(qemu-system-x86 busybox-static cpio g++ gzip)
+        BUILD_PKGS=(build-essential wget tar rsync bc flex bison unzip file git python3
+                    libncurses-dev libssl-dev libelf-dev)
+        INSTALL=(apt-get install -y)
+        REFRESH=(apt-get update) ;;
+    dnf)
+        RUN_PKGS=(qemu-system-x86 busybox cpio gcc-c++ gzip)
+        BUILD_PKGS=(make gcc gcc-c++ wget tar rsync bc flex bison unzip file git python3
+                    ncurses-devel openssl-devel elfutils-libelf-devel)
+        INSTALL=(dnf install -y)
+        REFRESH=(true) ;;
+    pacman)
+        RUN_PKGS=(qemu-system-x86 busybox cpio gcc gzip)
+        BUILD_PKGS=(base-devel wget tar rsync bc flex bison unzip file git python ncurses openssl)
+        INSTALL=(pacman -S --needed --noconfirm)
+        REFRESH=(true) ;;
+esac
+
+PKGS=("${RUN_PKGS[@]}")
+${MINIMAL} || PKGS+=("${BUILD_PKGS[@]}")
+
+echo "Package manager: ${PM}"
+echo "Mode:            $([ "${MINIMAL}" = true ] && echo 'RUN only (--minimal)' || echo 'RUN + BUILD')"
+echo "Packages:        ${PKGS[*]}"
+
+if [ "${DRY_RUN}" = true ]; then
+    echo "(--dry-run: nothing installed)"
+    exit 0
+fi
+
+SUDO=""
+[ "$(id -u)" -ne 0 ] && command -v sudo >/dev/null 2>&1 && SUDO="sudo"
+
+[ "${REFRESH[0]}" = true ] || ${SUDO} "${REFRESH[@]}"
+${SUDO} "${INSTALL[@]}" "${PKGS[@]}"
+
+echo ""
+echo "✓ prerequisites installed. Next:"
+${MINIMAL} && echo "  ./tests/qemu/run-qemu-test.sh --kernel <bzImage>" \
+           || echo "  ./tests/qemu/build-kernels.sh && ./tests/qemu/run-qemu-test.sh"

--- a/tests/qemu/README.md
+++ b/tests/qemu/README.md
@@ -1,0 +1,73 @@
+# QEMU binder round-trip test
+
+Optional, on-demand test that boots a target kernel under QEMU and runs a
+Binder **round-trip** against that kernel's driver. It is the runtime gate for
+the kernel-floor / protocol / bitness work ([#35](https://github.com/rdkcentral/linux_binder_idl/issues/35), [#36](https://github.com/rdkcentral/linux_binder_idl/pull/36) — pre-5.16 freeze fallbacks so 4.9 builds).
+
+**Why QEMU, not Docker:** Binder is a kernel driver, and Docker containers
+share the host kernel — a container matrix would only ever test one kernel.
+QEMU boots a real kernel per target, so the binder driver under test is the one
+that varies.
+
+## What it checks
+
+Inside the guest, `binder_roundtrip`:
+
+1. Opens `/dev/binder` via `ProcessState` — libbinder's strict `BINDER_VERSION`
+   check here catches a kernel/userspace **protocol mismatch** (the 7-vs-8 trap).
+2. Registers a test service with `servicemanager`,
+3. Fetches it back (a proxy routed through the kernel), and
+4. Transacts (41 → 42), exercising Parcel marshal → kernel → `onTransact` → reply.
+
+A single sentinel line is emitted and parsed by the host runner:
+`QEMU_BINDER_RESULT: PASS …` / `FAIL …`.
+
+## Usage
+
+```bash
+# 0. Install prerequisites (qemu, busybox, cpio, g++, + Buildroot deps).
+./tests/install.sh           # --minimal to skip the Buildroot kernel-build deps
+
+# 1. Build the kernel matrix (Buildroot; heavy, needs network + toolchain).
+./tests/qemu/build-kernels.sh
+#    or reuse a checkout / pick versions:
+#    BUILDROOT=/path/to/buildroot VERSIONS="4.9.337 5.10.205" ./tests/qemu/build-kernels.sh
+
+# 2. Boot each kernel and run the round-trip.
+./tests/qemu/run-qemu-test.sh
+#    single kernel / bring-your-own image:
+#    ./tests/qemu/run-qemu-test.sh --kernel /path/to/bzImage
+```
+
+The runner builds the repo's own binder target libraries
+(`build-linux-binder-aidl.sh`) for the guest userspace and assembles a small
+initramfs (busybox + libbinder/libutils + servicemanager + the test). It **skips cleanly** (not a failure) when QEMU,
+busybox, a compiler, or kernels are absent — so it never breaks a default run.
+
+## Matrix
+
+`build-kernels.sh` default versions span the supported range (4.9 floor → 5.16),
+one stable point release per minor. Protocol/bitness axes:
+
+| Variant | Kernel fragment | Userspace |
+| --- | --- | --- |
+| protocol 8 (default, mixed 32/64) | `kconfig/binder.fragment` | libbinder built without `BINDER_IPC_32BIT` |
+| protocol 7 (legacy all-32-bit) | `+ kconfig/binder-ipc32.fragment` (append `:ipc32` to a version) | libbinder built with `-DBINDER_IPC_32BIT=1` |
+
+## Extending to a HALIF interface
+
+`binder_roundtrip.cpp` is a binder-runtime gate; it carries a marked hook to
+add a generated-interface round-trip: link a snapshot's
+`lib<module>-v<ver>-cpp.so`, register the `Bn<Iface>` implementation, fetch it
+via `I<Iface>::asInterface(...)`, and assert a method result.
+
+## Files
+
+| File | Role |
+| --- | --- |
+| `build-kernels.sh` | Buildroot matrix kernel builder → `kernels/<ver>/bzImage` |
+| `run-qemu-test.sh` | builds SDK + test, assembles initramfs, boots each kernel, reports |
+| `binder_roundtrip.cpp` | in-guest binder round-trip (+ HALIF hook) |
+| `guest-init.sh` | guest PID 1: provision binder device, run test, poweroff |
+| `kconfig/binder.fragment` | kernel binder config (protocol 8) |
+| `kconfig/binder-ipc32.fragment` | legacy protocol-7 (32-bit) overlay |

--- a/tests/qemu/binder_roundtrip.cpp
+++ b/tests/qemu/binder_roundtrip.cpp
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2026 RDK Management
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// Minimal Binder round-trip, run inside the QEMU guest against the booted
+// kernel's binder driver. It proves the shipped libbinder runtime comes up and
+// completes a transaction on this kernel version:
+//
+//   1. ProcessState::self() opens /dev/binder and runs libbinder's strict
+//      BINDER_VERSION check — this alone catches a kernel/userspace protocol
+//      mismatch (the 7-vs-8 trap), which is the #1 porting failure mode.
+//   2. register a test service with servicemanager (must already be running),
+//   3. fetch it back (a proxy routed through the kernel), and
+//   4. transact: send 41, expect 42 — exercising Parcel marshal -> kernel ->
+//      unmarshal -> onTransact -> reply, end to end.
+//
+// Emits a single sentinel line the host runner greps for:
+//   QEMU_BINDER_RESULT: PASS ...   (exit 0)
+//   QEMU_BINDER_RESULT: FAIL ...   (exit 1)
+
+#include <binder/Binder.h>
+#include <binder/IPCThreadState.h>
+#include <binder/IServiceManager.h>
+#include <binder/Parcel.h>
+#include <binder/ProcessState.h>
+#include <utils/String16.h>
+#include <utils/StrongPointer.h>
+
+#include <cstdio>
+
+using namespace android;
+
+static const uint32_t TEST_CODE = IBinder::FIRST_CALL_TRANSACTION + 1;
+static const char* kServiceName = "rdk.binder.roundtrip.test";
+
+namespace {
+
+void pass(const char* detail) { printf("QEMU_BINDER_RESULT: PASS %s\n", detail); fflush(stdout); }
+int  fail(const char* detail) { printf("QEMU_BINDER_RESULT: FAIL %s\n", detail); fflush(stdout); return 1; }
+
+// Hosted in this process; servicemanager hands callers a proxy back to it.
+class TestService : public BBinder {
+public:
+    status_t onTransact(uint32_t code, const Parcel& data, Parcel* reply, uint32_t flags) override {
+        if (code == TEST_CODE) {
+            reply->writeInt32(data.readInt32() + 1);   // echo + 1
+            return OK;
+        }
+        return BBinder::onTransact(code, data, reply, flags);
+    }
+};
+
+}  // namespace
+
+int main() {
+    // 1. Driver open + protocol-version check happens here.
+    sp<ProcessState> proc = ProcessState::self();
+    proc->startThreadPool();
+
+    sp<IServiceManager> sm = defaultServiceManager();
+    if (sm == nullptr) return fail("no servicemanager (is it running?)");
+
+    // 2. register
+    sp<TestService> svc = new TestService();
+    if (sm->addService(String16(kServiceName), svc) != OK) return fail("addService failed");
+
+    // 3. fetch (non-blocking: checkService, so a misconfigured guest can't hang)
+    sp<IBinder> handle = sm->checkService(String16(kServiceName));
+    if (handle == nullptr) return fail("checkService returned null");
+
+    // 4. round-trip transaction
+    Parcel data, reply;
+    data.writeInt32(41);
+    status_t st = handle->transact(TEST_CODE, data, &reply);
+    if (st != OK) return fail("transact returned non-OK");
+    int32_t got = reply.readInt32();
+    if (got != 42) return fail("unexpected reply value");
+
+    pass("(servicemanager round-trip 41->42)");
+
+    // ---- HALIF interface hook -------------------------------------------------
+    // To exercise a generated HALIF interface end to end, link a snapshot's
+    // lib<module>-v<ver>-cpp.so, then here:
+    //   sp<Bn<Iface>> impl = new <VendorImpl>();
+    //   sm->addService(String16("<iface-name>"), impl);
+    //   sp<I<Iface>> p = I<Iface>::asInterface(sm->checkService(String16("<iface-name>")));
+    //   ... call a method and assert the result ...
+    // See tests/qemu/README.md.
+    // ---------------------------------------------------------------------------
+
+    return 0;
+}

--- a/tests/qemu/build-kernels.sh
+++ b/tests/qemu/build-kernels.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+#/**
+# * Copyright 2026 RDK Management
+# *
+# * Licensed under the Apache License, Version 2.0 (the "License");
+# * you may not use this file except in compliance with the License.
+# * You may obtain a copy of the License at
+# *
+# * http://www.apache.org/licenses/LICENSE-2.0
+# *
+# * Unless required by applicable law or agreed to in writing, software
+# * distributed under the License is distributed on an "AS IS" BASIS,
+# * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# * See the License for the specific language governing permissions and
+# * limitations under the License.
+# *
+# * SPDX-License-Identifier: Apache-2.0
+# */
+#
+# Build the QEMU test kernel matrix with Buildroot. For each version it builds
+# a bootable x86_64 bzImage with the Binder driver enabled (binder.fragment),
+# and drops it at tests/qemu/kernels/<version>/bzImage for run-qemu-test.sh.
+#
+# Buildroot is used only for the KERNEL (its kernel-build plumbing handles the
+# cross toolchain + config-fragment merge); the test's userspace comes from the
+# repo's own binder SDK, assembled into an initramfs by run-qemu-test.sh.
+#
+# Usage:
+#   ./tests/qemu/build-kernels.sh                 # default matrix
+#   VERSIONS="4.9.337 5.10.205 5.15.148" ./tests/qemu/build-kernels.sh
+#   BUILDROOT=/path/to/buildroot ./tests/qemu/build-kernels.sh   # reuse a checkout
+#
+# Heavy + needs network/toolchain; on-demand only. Each version builds in its
+# own Buildroot output dir so they don't clobber each other.
+set -uo pipefail
+
+HERE="$(cd "$(dirname "$(realpath "${BASH_SOURCE[0]}")")" && pwd)"
+OUT="${HERE}/kernels"
+FRAGMENT="${HERE}/kconfig/binder.fragment"
+IPC32_FRAGMENT="${HERE}/kconfig/binder-ipc32.fragment"
+
+# Default matrix — one stable point release per minor across the supported
+# range (4.9 floor → 5.16). IPC32=1 marks the legacy protocol-7 (all-32-bit)
+# variant, which also merges binder-ipc32.fragment.
+VERSIONS="${VERSIONS:-4.9.337 5.4.290 5.10.205 5.15.148 5.16.20}"
+BR_VERSION="${BR_VERSION:-2024.02.9}"
+
+die()  { echo "ERROR: $*" >&2; exit 1; }
+have() { command -v "$1" >/dev/null 2>&1; }
+
+# Buildroot needs a normal build toolchain + the usual fetchers.
+for t in make gcc g++ wget tar cpio rsync bc flex bison; do
+    have "$t" || die "missing build dependency: $t (Buildroot prerequisite)"
+done
+
+# Obtain Buildroot (reuse $BUILDROOT if provided).
+if [ -n "${BUILDROOT:-}" ]; then
+    [ -f "${BUILDROOT}/Makefile" ] || die "BUILDROOT=${BUILDROOT} is not a Buildroot checkout"
+else
+    BUILDROOT="${HERE}/.buildroot/buildroot-${BR_VERSION}"
+    if [ ! -f "${BUILDROOT}/Makefile" ]; then
+        mkdir -p "${HERE}/.buildroot"
+        echo "[buildroot] fetching ${BR_VERSION} ..."
+        wget -qO "${HERE}/.buildroot/br.tar.gz" \
+            "https://buildroot.org/downloads/buildroot-${BR_VERSION}.tar.gz" \
+            || die "failed to download Buildroot ${BR_VERSION}"
+        tar -xzf "${HERE}/.buildroot/br.tar.gz" -C "${HERE}/.buildroot" \
+            || die "failed to extract Buildroot tarball (partial download / disk full?)"
+    fi
+fi
+echo "[buildroot] using ${BUILDROOT}"
+
+mkdir -p "${OUT}"
+built=0
+for spec in ${VERSIONS}; do
+    ver="${spec%%:*}"
+    ipc32=false
+    case "${spec}" in *:ipc32) ipc32=true ;; esac
+    label="${ver}"; ${ipc32} && label="${ver}-ipc32"
+    o="${BUILDROOT}/output-${label}"
+    dest="${OUT}/${label}"
+
+    echo ""
+    echo "=== kernel ${label} ==="
+    # Minimal QEMU x86_64 target, custom kernel version, our binder fragment.
+    frags="${FRAGMENT}"; ${ipc32} && frags="${FRAGMENT} ${IPC32_FRAGMENT}"
+    cat > "${o}.config" <<EOF
+BR2_x86_64=y
+BR2_TOOLCHAIN_BUILDROOT_CXX=y
+BR2_LINUX_KERNEL=y
+BR2_LINUX_KERNEL_CUSTOM_VERSION=y
+BR2_LINUX_KERNEL_CUSTOM_VERSION_VALUE="${ver}"
+BR2_LINUX_KERNEL_DEFCONFIG="x86_64"
+BR2_LINUX_KERNEL_CONFIG_FRAGMENT_FILES="${frags}"
+BR2_LINUX_KERNEL_BZIMAGE=y
+EOF
+    if ! make -C "${BUILDROOT}" O="${o}" defconfig BR2_DEFCONFIG="${o}.config" >/dev/null 2>&1; then
+        echo "  FAIL  ${label}: buildroot defconfig failed"; continue
+    fi
+    if ! make -C "${BUILDROOT}" O="${o}" linux >"${o}.build.log" 2>&1; then
+        echo "  FAIL  ${label}: kernel build failed — see ${o}.build.log"; continue
+    fi
+    img="$(find "${o}/images" -name 'bzImage' -type f 2>/dev/null | head -1)"
+    if [ -z "${img}" ]; then echo "  FAIL  ${label}: no bzImage produced"; continue; fi
+    mkdir -p "${dest}"; cp "${img}" "${dest}/bzImage"
+    echo "  OK    ${label}: ${dest}/bzImage"
+    built=$((built + 1))
+done
+
+echo ""
+echo "[buildroot] built ${built} kernel(s) into ${OUT}/"
+[ "${built}" -gt 0 ] || die "no kernels built"
+echo "Next: ./tests/qemu/run-qemu-test.sh"

--- a/tests/qemu/guest-init.sh
+++ b/tests/qemu/guest-init.sh
@@ -1,0 +1,55 @@
+#!/bin/sh
+#/**
+# * Copyright 2026 RDK Management
+# *
+# * Licensed under the Apache License, Version 2.0 (the "License");
+# * you may not use this file except in compliance with the License.
+# * You may obtain a copy of the License at
+# *
+# * http://www.apache.org/licenses/LICENSE-2.0
+# *
+# * Unless required by applicable law or agreed to in writing, software
+# * distributed under the License is distributed on an "AS IS" BASIS,
+# * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# * See the License for the specific language governing permissions and
+# * limitations under the License.
+# *
+# * SPDX-License-Identifier: Apache-2.0
+# */
+#
+# PID 1 inside the QEMU guest. Mounts the pseudo-filesystems, provisions the
+# binder device for this kernel, starts servicemanager, runs the binder
+# round-trip, prints its sentinel, then powers off so QEMU exits.
+set -u
+
+mount -t proc     proc     /proc      2>/dev/null
+mount -t sysfs    sysfs    /sys       2>/dev/null
+mount -t devtmpfs devtmpfs /dev       2>/dev/null
+
+export LD_LIBRARY_PATH=/opt/binder/lib
+
+# Provision /dev/binder. Kernels >= 5.0 expose binderfs; create the device
+# there. Older kernels rely on the static node from CONFIG_ANDROID_BINDER_DEVICES.
+if [ ! -e /dev/binder ]; then
+    if mkdir -p /dev/binderfs && mount -t binder binder /dev/binderfs 2>/dev/null; then
+        echo binder > /dev/binderfs/binder-control 2>/dev/null
+        [ -e /dev/binderfs/binder ] && ln -sf /dev/binderfs/binder /dev/binder
+    fi
+fi
+if [ ! -e /dev/binder ]; then
+    echo "QEMU_BINDER_RESULT: FAIL no /dev/binder on kernel $(uname -r)"
+    poweroff -f
+    exit 1            # deterministic stop if poweroff is delayed/fails
+fi
+
+# servicemanager must own the context before the test calls defaultServiceManager().
+# It has no readiness file to poll, so give it a brief moment to register as the
+# context manager (BINDER_SET_CONTEXT_MGR) before the test connects.
+/opt/binder/bin/servicemanager >/dev/null 2>&1 &
+sleep 2
+
+echo "QEMU_BINDER_KERNEL: $(uname -r)"
+/opt/binder/bin/binder_roundtrip
+echo "QEMU_BINDER_DONE"
+
+poweroff -f

--- a/tests/qemu/kconfig/binder-ipc32.fragment
+++ b/tests/qemu/kconfig/binder-ipc32.fragment
@@ -1,0 +1,6 @@
+# Legacy 32-bit binder protocol (version 7) variant.
+# Apply IN ADDITION to binder.fragment for the all-32-bit-userspace matrix
+# entry, where MW and vendor are both 32-bit and the userspace libbinder is
+# built with -DBINDER_IPC_32BIT=1. A protocol-8 (64-bit) userspace will FAIL
+# libbinder's version check against a kernel built with this set.
+CONFIG_ANDROID_BINDER_IPC_32BIT=y

--- a/tests/qemu/kconfig/binder.fragment
+++ b/tests/qemu/kconfig/binder.fragment
@@ -1,0 +1,17 @@
+# Binder kernel-config fragment (protocol 8 / mixed 32-64 default).
+# Merged onto a QEMU-bootable base defconfig by build-kernels.sh.
+#
+# Leave CONFIG_ANDROID_BINDER_IPC_32BIT unset here: a 64-bit kernel serving
+# 32-bit userspace over the compat path uses protocol 8. For the legacy
+# all-32-bit-userspace (protocol 7) matrix entry, use binder-ipc32.fragment.
+CONFIG_ANDROID=y
+CONFIG_ANDROID_BINDER_IPC=y
+CONFIG_ANDROID_BINDERFS=y
+CONFIG_ANDROID_BINDER_DEVICES="binder,hwbinder,vndbinder"
+# Serial console + initramfs boot (QEMU -kernel/-initrd):
+CONFIG_TTY=y
+CONFIG_SERIAL_8250=y
+CONFIG_SERIAL_8250_CONSOLE=y
+CONFIG_BLK_DEV_INITRD=y
+CONFIG_DEVTMPFS=y
+CONFIG_DEVTMPFS_MOUNT=y

--- a/tests/qemu/run-qemu-test.sh
+++ b/tests/qemu/run-qemu-test.sh
@@ -1,0 +1,168 @@
+#!/usr/bin/env bash
+#/**
+# * Copyright 2026 RDK Management
+# *
+# * Licensed under the Apache License, Version 2.0 (the "License");
+# * you may not use this file except in compliance with the License.
+# * You may obtain a copy of the License at
+# *
+# * http://www.apache.org/licenses/LICENSE-2.0
+# *
+# * Unless required by applicable law or agreed to in writing, software
+# * distributed under the License is distributed on an "AS IS" BASIS,
+# * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# * See the License for the specific language governing permissions and
+# * limitations under the License.
+# *
+# * SPDX-License-Identifier: Apache-2.0
+# */
+#
+# Optional QEMU binder round-trip test. Boots each target kernel with a tiny
+# initramfs (binder SDK + servicemanager + binder_roundtrip) and checks the
+# guest completes a binder transaction on that kernel.
+#
+# This is the runtime gate for the kernel-floor / protocol / bitness work
+# (linux_binder_idl#35 / #36). Docker can't do it — containers share the host
+# kernel — so we boot real kernels under QEMU.
+#
+# Usage:
+#   ./tests/qemu/run-qemu-test.sh                 # all kernels under tests/qemu/kernels/
+#   ./tests/qemu/run-qemu-test.sh --kernel <bzImage>
+#   KERNELS="a/bzImage b/bzImage" ./tests/qemu/run-qemu-test.sh
+#   ./tests/qemu/run-qemu-test.sh --keep          # keep the work dir
+#
+# Build kernels first with ./tests/qemu/build-kernels.sh (or supply your own).
+# Exit: 0 = all booted kernels passed (or cleanly skipped); 1 = a failure.
+set -uo pipefail
+
+HERE="$(cd "$(dirname "$(realpath "${BASH_SOURCE[0]}")")" && pwd)"
+REPO_ROOT="$(cd "${HERE}/../.." && pwd)"
+KERNEL_DIR="${HERE}/kernels"
+QEMU="${QEMU:-qemu-system-x86_64}"
+KEEP=false
+KERNEL_ARG=""
+TIMEOUT="${QEMU_TIMEOUT:-90}"
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --kernel) [ $# -ge 2 ] || { echo "--kernel needs a path" >&2; exit 2; }; KERNEL_ARG="$2"; shift 2 ;;
+        --keep)   KEEP=true; shift ;;
+        -h|--help) sed -n '20,33p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'; exit 0 ;;
+        *) echo "Unknown option: $1" >&2; exit 2 ;;
+    esac
+done
+
+skip() { echo "  SKIP  qemu binder test — $1"; exit 0; }   # absence of tooling is not a failure
+fail() { echo "  FAIL  qemu binder test — $1"; exit 1; }   # once opted in, real errors must fail
+
+# ---- Prerequisites (skip cleanly when missing) -----------------------------
+CXX="${CXX:-g++}"
+for tool in "${QEMU}" busybox cpio "${CXX}" timeout gzip ldd; do
+    command -v "${tool}" >/dev/null 2>&1 || skip "${tool} not installed"
+done
+BUSYBOX="$(command -v busybox)"
+
+# Collect kernels.
+KERNELS_LIST=()
+if [ -n "${KERNEL_ARG}" ]; then
+    KERNELS_LIST=("${KERNEL_ARG}")
+elif [ -n "${KERNELS:-}" ]; then
+    # shellcheck disable=SC2206
+    KERNELS_LIST=(${KERNELS})
+else
+    while IFS= read -r k; do KERNELS_LIST+=("$k"); done \
+        < <(find "${KERNEL_DIR}" -name 'bzImage' -type f 2>/dev/null | sort)
+fi
+[ "${#KERNELS_LIST[@]}" -gt 0 ] || skip "no kernels found (run ./tests/qemu/build-kernels.sh or pass --kernel/KERNELS)"
+
+# ---- Binder target build (build-linux-binder-aidl.sh) ----------------------
+SM_BIN="${REPO_ROOT}/out/target/bin/servicemanager"
+if [ ! -x "${SM_BIN}" ]; then
+    echo "  building binder target libs (build-linux-binder-aidl.sh) ..."
+    (cd "${REPO_ROOT}" && ./build-linux-binder-aidl.sh) >/dev/null 2>&1 \
+        || fail "build-linux-binder-aidl.sh failed (binder target libs could not be built)"
+fi
+SDK_LIB="${REPO_ROOT}/out/target/lib"
+# Headers install under out/target/include; accept a couple of layouts so an
+# upstream header-path change doesn't silently skip the test.
+SDK_INC=""
+for _c in "${REPO_ROOT}/out/target/include/binder_sdk" "${REPO_ROOT}/out/target/include"; do
+    [ -d "${_c}" ] && { SDK_INC="${_c}"; break; }
+done
+[ -d "${SDK_LIB}" ] && [ -n "${SDK_INC}" ] || skip "binder target libs/headers not staged (${SDK_LIB})"
+[ -x "${SM_BIN}" ] || skip "servicemanager not built at ${SM_BIN}"
+
+WORK="$(mktemp -d "${TMPDIR:-/tmp}/qemu-binder.XXXXXX")"
+cleanup() { [ "${KEEP}" = true ] || rm -rf "${WORK}"; }
+trap cleanup EXIT
+ROOT="${WORK}/rootfs"
+
+# ---- Build the in-guest test binary ----------------------------------------
+echo "  compiling binder_roundtrip ..."
+"${CXX}" -std=c++17 -O1 -Wno-attributes -Wno-write-strings -Wno-return-type \
+    "${HERE}/binder_roundtrip.cpp" \
+    -I"${SDK_INC}" -L"${SDK_LIB}" -lbinder -lutils -lbase -lcutils -llog \
+    -Wl,-rpath,/opt/binder/lib -o "${WORK}/binder_roundtrip" \
+    || fail "binder_roundtrip failed to compile/link against the SDK (ABI or flags regression?)"
+
+# ---- Assemble the initramfs ------------------------------------------------
+mkdir -p "${ROOT}"/{bin,sbin,proc,sys,dev,opt/binder/bin,opt/binder/lib,lib,lib64}
+cp "${BUSYBOX}" "${ROOT}/bin/busybox"
+for a in sh mount ln sleep poweroff mkdir cat; do ln -sf busybox "${ROOT}/bin/${a}"; done
+cp "${WORK}/binder_roundtrip" "${ROOT}/opt/binder/bin/"
+cp "${SM_BIN}"                "${ROOT}/opt/binder/bin/servicemanager"
+cp -a "${SDK_LIB}/." "${ROOT}/opt/binder/lib/"
+cp "${HERE}/guest-init.sh" "${ROOT}/init"; chmod +x "${ROOT}/init"
+
+# Copy each binary's SYSTEM shared-lib closure + the ELF interpreter into the
+# rootfs, preserving paths, so the guest userspace resolves at runtime. SDK libs
+# are skipped here — they're already staged at /opt/binder/lib and found via the
+# binary's rpath; copying them under their host repo paths would only bloat the
+# initramfs and not match the guest layout.
+copy_deps() {
+    local bin="$1" dep
+    LD_LIBRARY_PATH="${SDK_LIB}" ldd "${bin}" 2>/dev/null | awk '{for(i=1;i<=NF;i++) if($i ~ /^\//) print $i}' \
+    | while read -r dep; do
+        [ -f "${dep}" ] || continue
+        case "${dep}" in "${SDK_LIB}"/*) continue ;; esac   # SDK libs already at /opt/binder/lib
+        mkdir -p "${ROOT}$(dirname "${dep}")"
+        cp -n "${dep}" "${ROOT}${dep}" 2>/dev/null || true
+    done
+}
+copy_deps "${WORK}/binder_roundtrip"
+copy_deps "${SM_BIN}"
+copy_deps "${BUSYBOX}"
+
+INITRAMFS="${WORK}/initramfs.cpio.gz"
+(cd "${ROOT}" && find . | cpio -o -H newc 2>/dev/null | gzip) > "${INITRAMFS}"
+
+# ---- Boot each kernel ------------------------------------------------------
+FAIL=0; PASS=0; SKIPPED=0
+for kimg in "${KERNELS_LIST[@]}"; do
+    if [ ! -f "${kimg}" ]; then echo "  SKIP  ${kimg} (not found)"; SKIPPED=$((SKIPPED+1)); continue; fi
+    label="$(basename "$(dirname "${kimg}")")"
+    log="${WORK}/qemu-${label}.log"
+    echo "[qemu] booting kernel: ${label} (${kimg})"
+    timeout "${TIMEOUT}" "${QEMU}" \
+        -m 512 -no-reboot -nographic \
+        -kernel "${kimg}" -initrd "${INITRAMFS}" \
+        -append "console=ttyS0 rdinit=/init panic=-1 loglevel=3" \
+        >"${log}" 2>&1 || true
+
+    if grep -q 'QEMU_BINDER_RESULT: PASS' "${log}"; then
+        echo "  PASS  ${label}: $(grep -o 'QEMU_BINDER_RESULT: PASS.*' "${log}" | head -1)"
+        PASS=$((PASS+1))
+    elif grep -q 'QEMU_BINDER_RESULT: FAIL' "${log}"; then
+        echo "  FAIL  ${label}: $(grep -o 'QEMU_BINDER_RESULT: FAIL.*' "${log}" | head -1)"
+        FAIL=$((FAIL+1))
+    else
+        echo "  FAIL  ${label}: no result sentinel (boot/timeout?) — see ${log}"
+        [ "${KEEP}" = true ] || tail -15 "${log}" | sed 's/^/        /'
+        FAIL=$((FAIL+1))
+    fi
+done
+
+echo ""
+echo "  qemu binder test: ${PASS} passed, ${FAIL} failed, ${SKIPPED} skipped"
+[ "${KEEP}" = true ] && echo "  work dir kept: ${WORK}"
+[ "${FAIL}" -eq 0 ]

--- a/tests/test_qemu_binder.sh
+++ b/tests/test_qemu_binder.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+#/**
+# * Copyright 2026 RDK Management
+# *
+# * Licensed under the Apache License, Version 2.0 (the "License");
+# * you may not use this file except in compliance with the License.
+# * You may obtain a copy of the License at
+# *
+# * http://www.apache.org/licenses/LICENSE-2.0
+# *
+# * Unless required by applicable law or agreed to in writing, software
+# * distributed under the License is distributed on an "AS IS" BASIS,
+# * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# * See the License for the specific language governing permissions and
+# * limitations under the License.
+# *
+# * SPDX-License-Identifier: Apache-2.0
+# */
+#
+# Thin wrapper so tests/run-tests.sh (which auto-discovers tests/test_*.sh)
+# picks up the optional QEMU binder round-trip test. The real harness lives at
+# tests/qemu/run-qemu-test.sh; it skips cleanly when QEMU/busybox/a compiler or
+# built kernels are absent, so it never breaks a default suite run.
+exec "$(dirname "$(realpath "${BASH_SOURCE[0]}")")/qemu/run-qemu-test.sh" "$@"


### PR DESCRIPTION
## What

Optional **QEMU binder round-trip test** — boots each target kernel under QEMU and verifies a Binder transaction completes on that kernel's driver.

**Relocated from rdk-halif-aidl#664/#665.** It tests the binder driver/runtime (not any HAL AIDL), and validates the kernel-floor work in this repo (#35/#36 pre-5.16 freeze fallbacks). It belongs next to what it tests.

## Adapted for linux_binder_idl
- Builds via `build-linux-binder-aidl.sh` and the flat `out/target/{lib,bin,include}` layout (was rdk-halif-aidl's `build_binder.sh` + nested `lib/binder` + split `out/build`).
- `tests/test_qemu_binder.sh` wires it into `run-tests.sh` auto-discovery.
- `tests/install.sh` installs prerequisites (qemu/busybox/cpio/g++ + Buildroot).
- Skips cleanly when QEMU/tools/kernels are absent.

Closes #40