### PR TITLE
build: forward BINDER_IPC_32BIT in wrapper + install multilib (#46)

### DIFF
--- a/build-linux-binder-aidl.sh
+++ b/build-linux-binder-aidl.sh
@@ -212,12 +212,13 @@ CMAKE_ARGS=(
   -DTARGET_LIB32_VERSION="${TARGET_LIB32}"
 )
 
-# Binder wire protocol is decoupled from compile bitness (#42): forward
-# BINDER_IPC_32BIT when set so a 32-bit build can select protocol 8
-# (BINDER_IPC_32BIT=OFF). Unset -> CMake defaults it to follow the bitness.
-if [ -n "${BINDER_IPC_32BIT:-}" ]; then
-  CMAKE_ARGS+=(-DBINDER_IPC_32BIT="${BINDER_IPC_32BIT}")
-fi
+# Binder wire protocol, decoupled from compile bitness (#42). Always pass an
+# explicit BOOL so a value cached from an earlier run in the reused build-target
+# dir can't silently stick (e.g. a prior BINDER_IPC_32BIT=OFF run leaving the
+# cache at protocol 8). When the env var is unset, default it to follow the
+# compile bitness (32-bit -> protocol 7), matching CMakeLists.txt's default.
+BINDER_IPC_32BIT_ARG="${BINDER_IPC_32BIT:-${TARGET_LIB32}}"
+CMAKE_ARGS+=(-DBINDER_IPC_32BIT:BOOL="${BINDER_IPC_32BIT_ARG}")
 
 # When OE SDK cmake is used, the OEToolchainConfig.cmake handles compiler,
 # sysroot, and flags from the environment. We've already prepended the arch

--- a/build-linux-binder-aidl.sh
+++ b/build-linux-binder-aidl.sh
@@ -212,6 +212,13 @@ CMAKE_ARGS=(
   -DTARGET_LIB32_VERSION="${TARGET_LIB32}"
 )
 
+# Binder wire protocol is decoupled from compile bitness (#42): forward
+# BINDER_IPC_32BIT when set so a 32-bit build can select protocol 8
+# (BINDER_IPC_32BIT=OFF). Unset -> CMake defaults it to follow the bitness.
+if [ -n "${BINDER_IPC_32BIT:-}" ]; then
+  CMAKE_ARGS+=(-DBINDER_IPC_32BIT="${BINDER_IPC_32BIT}")
+fi
+
 # When OE SDK cmake is used, the OEToolchainConfig.cmake handles compiler,
 # sysroot, and flags from the environment. We've already prepended the arch
 # flags from CC/CXX into CFLAGS/CXXFLAGS, so the toolchain picks them up.

--- a/tests/install.sh
+++ b/tests/install.sh
@@ -53,21 +53,24 @@ elif command -v pacman  >/dev/null 2>&1; then PM=pacman
 else echo "ERROR: no supported package manager (apt/dnf/pacman) found." >&2; exit 1; fi
 
 case "${PM}" in
+    # Note: the *-multilib / .i686 packages provide the 32-bit (-m32) toolchain
+    # for building a 32-bit binder locally on an x86_64 host (real targets use an
+    # ARM cross-toolchain instead). Needed for the default TARGET_LIB32 build.
     apt)
         RUN_PKGS=(qemu-system-x86 busybox-static cpio g++ gzip)
-        BUILD_PKGS=(build-essential wget tar rsync bc flex bison unzip file git python3
-                    libncurses-dev libssl-dev libelf-dev)
+        BUILD_PKGS=(build-essential gcc-multilib g++-multilib wget tar rsync bc flex bison
+                    unzip file git python3 libncurses-dev libssl-dev libelf-dev)
         INSTALL=(apt-get install -y)
         REFRESH=(apt-get update) ;;
     dnf)
         RUN_PKGS=(qemu-system-x86 busybox cpio gcc-c++ gzip)
-        BUILD_PKGS=(make gcc gcc-c++ wget tar rsync bc flex bison unzip file git python3
-                    ncurses-devel openssl-devel elfutils-libelf-devel)
+        BUILD_PKGS=(make gcc gcc-c++ glibc-devel.i686 libstdc++-devel.i686 wget tar rsync bc
+                    flex bison unzip file git python3 ncurses-devel openssl-devel elfutils-libelf-devel)
         INSTALL=(dnf install -y)
         REFRESH=(true) ;;
     pacman)
         RUN_PKGS=(qemu-system-x86 busybox cpio gcc gzip)
-        BUILD_PKGS=(base-devel wget tar rsync bc flex bison unzip file git python ncurses openssl)
+        BUILD_PKGS=(base-devel lib32-gcc-libs wget tar rsync bc flex bison unzip file git python ncurses openssl)
         INSTALL=(pacman -S --needed --noconfirm)
         REFRESH=(true) ;;
 esac


### PR DESCRIPTION
Follow-ups from verifying #42 end-to-end:
1. `build-linux-binder-aidl.sh` now **forwards `BINDER_IPC_32BIT`** to CMake — the #42 protocol option was otherwise only selectable via a raw `cmake -D`.
2. `tests/install.sh` now installs the **32-bit multilib** toolchain (apt `gcc-multilib`/`g++-multilib`, dnf `.i686`, pacman `lib32-gcc-libs`) in the BUILD group — the default `TARGET_LIB32` build needs it for a local x86_64 32-bit build.

**Verified:** 64-bit / 32-bit-proto7 / 32-bit-proto8 all configure with the correct wire protocol (8/7/8); the 4.9-floor header build and full test suite pass (5/5).

Closes #46