### PR TITLE
feat(toolchain): dump-surface + diff-surface for AIDL structural classification (#27)

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,41 @@ aidl --lang=cpp -I. com/test/IFWManager.aidl --header_out gen/FWManager/include 
 #The stubs and proxies are generated in gen/FWManager and gen/FWManager/include
 ```
 
+### AIDL Surface Dump & Structural Diff
+
+`aidl_ops` can dump the declared surface of an AIDL tree (interfaces,
+parcelables, unions, enums — method signatures, field types, enum values with
+backing ints, annotations) as canonical, deterministic text, and classify the
+structural difference between two dumps. Declaration order is ABI (transaction
+ids / parcel order), so removals, changes and reorders classify as `breaking`,
+append-only additions as `major`, and identical surfaces as `none`. Doc
+comments are stripped at dump time, so comment-only edits produce
+byte-identical dumps.
+
+```bash
+# Dump a module's surface
+host/aidl_ops.py dump-surface path/to/module/aidl --out old.txt
+
+# ... edit the AIDL ...
+host/aidl_ops.py dump-surface path/to/module/aidl --out new.txt
+
+# Classify the change (text report, or --json for machine consumption)
+host/aidl_ops.py diff-surface old.txt new.txt --json
+# {
+#   "class": "major",
+#   "changes": [
+#     {"kind": "method_added",
+#      "where": "interface com.test.IFWManager",
+#      "symbol": "void gamma()"}
+#   ]
+# }
+```
+
+Consumers (e.g. rdk-halif-aidl's release audit) use this to validate that a
+declared version bump matches what the AIDL actually changed: `breaking` =>
+major bump, `major` (additive) => minor bump, equal dumps with differing
+sources => doc-only bump.
+
 ---
 
 ## Build Options

--- a/host/aidl_ops.py
+++ b/host/aidl_ops.py
@@ -32,6 +32,14 @@
         Generates dependency tree of interface libraries(stubs and proxies)
         of interfaces defined in given directories
 
+    aidl_ops dump-surface <aidl-root> [--out FILE]
+        Prints a canonical, deterministic text dump of the AIDL surface
+        declared under <aidl-root> (see host/aidl_surface.py)
+
+    aidl_ops diff-surface <old-dump> <new-dump> [--json]
+        Structurally compares two dump-surface outputs and classifies the
+        change as breaking / major / none (see host/aidl_surface.py)
+
     OPTIONS:
         -r DIRS(--interfaces_roots=DIRS)
             ";" separated list of root directories where interfaces are located
@@ -138,6 +146,11 @@ def handle_aidl_gen_deps():
 
 
 def main(argv):
+    # Surface subcommands (#27) are self-contained and bypass getopt.
+    if argv and argv[0] in ("dump-surface", "diff-surface"):
+        import aidl_surface
+        sys.exit(aidl_surface.main(argv))
+
     error = 0
     global _interface_name
     global _operation

--- a/host/aidl_surface.py
+++ b/host/aidl_surface.py
@@ -63,8 +63,8 @@ def strip_comments(text):
     out = []
     i, n = 0, len(text)
     while i < n:
-        c = text[i]
-        if c == '"':
+        ch = text[i]
+        if ch == '"':
             j = i + 1
             while j < n and text[j] != '"':
                 j += 2 if text[j] == '\\' else 1
@@ -78,7 +78,7 @@ def strip_comments(text):
             i = n if j < 0 else j + 2
             out.append(' ')
         else:
-            out.append(c)
+            out.append(ch)
             i += 1
     return ''.join(out)
 
@@ -102,8 +102,8 @@ def _split_statements(body):
     i, n = 0, len(body)
     buf = ''
     while i < n:
-        c = body[i]
-        if c == '{':
+        ch = body[i]
+        if ch == '{':
             # matched-brace body for a nested declaration
             depth, j = 1, i + 1
             while j < n and depth:
@@ -112,13 +112,13 @@ def _split_statements(body):
             yield ('decl', (buf.strip(), body[i + 1:j - 1]))
             buf = ''
             i = j
-        elif c == ';':
+        elif ch == ';':
             if buf.strip():
                 yield ('stmt', buf.strip())
             buf = ''
             i += 1
         else:
-            buf += c
+            buf += ch
             i += 1
     if buf.strip():
         yield ('stmt', buf.strip())
@@ -392,12 +392,12 @@ def diff_surface(old_text, new_text):
             _diff_sequence(o['kind'], where, o_rest, n_rest,
                            member_kind, changes)
     overall = 'none'
-    if any(c['class'] == 'breaking' for c in changes):
+    if any(change['class'] == 'breaking' for change in changes):
         overall = 'breaking'
-    elif any(c['class'] == 'major' for c in changes):
+    elif any(change['class'] == 'major' for change in changes):
         overall = 'major'
-    for c in changes:
-        del c['class']
+    for change in changes:
+        del change['class']
     return {'class': overall, 'changes': changes}
 
 
@@ -451,12 +451,13 @@ def main(argv):
             print(json.dumps(report, indent=2))
         else:
             print('class: %s' % report['class'])
-            for c in report['changes']:
-                line = '  %s  %s  %s' % (c['kind'], c['where'], c['symbol'])
-                if 'old' in c:
-                    line += '  [old: %s]' % c['old']
-                if 'new' in c:
-                    line += '  [new: %s]' % c['new']
+            for change in report['changes']:
+                line = '  %s  %s  %s' % (
+                    change['kind'], change['where'], change['symbol'])
+                if 'old' in change:
+                    line += '  [old: %s]' % change['old']
+                if 'new' in change:
+                    line += '  [new: %s]' % change['new']
                 print(line)
         return 0
     sys.stderr.write('aidl_surface: unknown operation %r\n' % op)

--- a/host/aidl_surface.py
+++ b/host/aidl_surface.py
@@ -1,0 +1,461 @@
+#!/usr/bin/env python3
+#/**
+# * Copyright 2026 RDK Management
+# *
+# * Licensed under the Apache License, Version 2.0 (the "License");
+# * you may not use this file except in compliance with the License.
+# * You may obtain a copy of the License at
+# *
+# * http://www.apache.org/licenses/LICENSE-2.0
+# *
+# * Unless required by applicable law or agreed to in writing, software
+# * distributed under the License is distributed on an "AS IS" BASIS,
+# * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# * See the License for the specific language governing permissions and
+# * limitations under the License.
+# *
+# * SPDX-License-Identifier: Apache-2.0
+# */
+"""
+aidl_surface - canonical AIDL surface dump + structural diff (#27).
+
+    aidl_ops dump-surface <aidl-root> [--out FILE]
+        Parse every .aidl under <aidl-root> and print a canonical,
+        deterministic text dump of the declared surface: interfaces,
+        parcelables, unions and enums with method signatures, field types,
+        enum values + backing ints and AIDL annotations. Comments are
+        stripped; types are sorted by qualified name; members keep
+        declaration order (it is ABI: transaction ids / parcel order).
+
+    aidl_ops diff-surface <old-dump> <new-dump> [--json]
+        Structurally compare two dump-surface outputs and classify:
+          breaking - a client built against <old> can break against <new>
+                     (member removed / changed / reordered, enum int
+                     changed, annotation changed, ...)
+          major    - purely additive (member appended, enum value added,
+                     new type)
+          none     - no structural difference
+        Doc-only changes never appear here (comments are stripped at dump
+        time): equal dumps + differing sources is the consumer's doc-only
+        signal. Exit code is 0 for any successful classification; 2 on
+        usage/parse errors.
+"""
+
+import json
+import os
+import re
+import sys
+
+DECL_KINDS = ("interface", "parcelable", "union", "enum")
+_DECL_RE = re.compile(
+    r'^(?P<oneway>oneway\s+)?(?P<kind>interface|parcelable|union|enum)\s+'
+    r'(?P<name>\w+)\s*(?P<term>[{;])')
+_ANNOTATION_RE = re.compile(r'@\w+(\s*\([^)]*\))?')
+_INT_RE = re.compile(r'^[+-]?(0[xX][0-9a-fA-F]+|\d+)$')
+
+
+# ---------------------------------------------------------------------------
+# Parsing .aidl sources
+# ---------------------------------------------------------------------------
+
+def strip_comments(text):
+    """Remove // and /* */ comments, preserving string literals."""
+    out = []
+    i, n = 0, len(text)
+    while i < n:
+        c = text[i]
+        if c == '"':
+            j = i + 1
+            while j < n and text[j] != '"':
+                j += 2 if text[j] == '\\' else 1
+            out.append(text[i:j + 1])
+            i = j + 1
+        elif text.startswith('//', i):
+            j = text.find('\n', i)
+            i = n if j < 0 else j
+        elif text.startswith('/*', i):
+            j = text.find('*/', i + 2)
+            i = n if j < 0 else j + 2
+            out.append(' ')
+        else:
+            out.append(c)
+            i += 1
+    return ''.join(out)
+
+
+def _normalize(stmt):
+    """Collapse whitespace and normalize punctuation spacing."""
+    s = re.sub(r'\s+', ' ', stmt).strip()
+    s = re.sub(r'\s*([(),;=\[\]])\s*', r'\1', s)
+    s = s.replace(',', ', ').replace('=', ' = ')
+    s = re.sub(r'\](\w)', r'] \1', s)   # `Codec[] name`, not `Codec[]name`
+    # '(' after identifier stays tight; parameters got ', ' separators above.
+    return s.strip()
+
+
+def _split_statements(body):
+    """Split a declaration body into top-level statements.
+
+    Yields (kind, text) where kind is 'decl' for a nested type declaration
+    (text = (header, inner_body)) or 'stmt' for a ';'-terminated statement.
+    """
+    i, n = 0, len(body)
+    buf = ''
+    while i < n:
+        c = body[i]
+        if c == '{':
+            # matched-brace body for a nested declaration
+            depth, j = 1, i + 1
+            while j < n and depth:
+                depth += {'{': 1, '}': -1}.get(body[j], 0)
+                j += 1
+            yield ('decl', (buf.strip(), body[i + 1:j - 1]))
+            buf = ''
+            i = j
+        elif c == ';':
+            if buf.strip():
+                yield ('stmt', buf.strip())
+            buf = ''
+            i += 1
+        else:
+            buf += c
+            i += 1
+    if buf.strip():
+        yield ('stmt', buf.strip())
+
+
+def _take_annotations(text):
+    """Split leading annotations off a declaration/statement."""
+    anns = []
+    rest = text.strip()
+    while True:
+        m = _ANNOTATION_RE.match(rest)
+        if not m:
+            return anns, rest
+        anns.append(re.sub(r'\s+', '', m.group(0)))
+        rest = rest[m.end():].strip()
+
+
+def _parse_enum_body(body):
+    """Enum values with computed backing ints where derivable."""
+    members = []
+    prev = -1
+    for value in body.split(','):
+        value = value.strip()
+        if not value:
+            continue
+        if '=' in value:
+            name, _, expr = value.partition('=')
+            name, expr = name.strip(), expr.strip()
+            if _INT_RE.match(expr):
+                prev = int(expr, 0)
+                members.append('%s = %d' % (name, prev))
+            else:
+                members.append('%s = %s' % (name, _normalize(expr)))
+                prev = None
+        else:
+            prev = None if prev is None else prev + 1
+            members.append(
+                '%s = %d' % (value, prev) if prev is not None else value)
+    return members
+
+
+def _parse_type(header, body, package, outer, types):
+    anns, rest = _take_annotations(header)
+    m = _DECL_RE.match(rest + ' {')
+    if not m:
+        return
+    kind, name = m.group('kind'), m.group('name')
+    oneway = bool(m.group('oneway'))
+    qname = '.'.join(x for x in (package, outer, name) if x)
+    members = []
+    if kind == 'enum':
+        members = _parse_enum_body(body)
+    else:
+        for skind, item in _split_statements(body):
+            if skind == 'decl':
+                _parse_type(item[0], item[1], package,
+                            '.'.join(x for x in (outer, name) if x), types)
+            else:
+                members.append(_normalize(item))
+    types[qname] = {
+        'kind': kind,
+        'oneway': oneway,
+        'annotations': sorted(anns),
+        'members': members,
+    }
+
+
+def parse_aidl(text, types):
+    """Parse one .aidl file's text into the types dict."""
+    text = strip_comments(text)
+    package = ''
+    pm = re.search(r'\bpackage\s+([\w.]+)\s*;', text)
+    if pm:
+        package = pm.group(1)
+    # Remove package/import statements, then parse top-level declarations.
+    text = re.sub(r'\b(package|import)\s+[\w.*]+\s*;', '', text)
+    for skind, item in _split_statements(text):
+        if skind == 'decl':
+            _parse_type(item[0], item[1], package, '', types)
+        else:
+            # Unstructured forward declaration: `parcelable X;`
+            anns, rest = _take_annotations(item)
+            m = _DECL_RE.match(rest + ' ;')
+            if m:
+                qname = '.'.join(
+                    x for x in (package, m.group('name')) if x)
+                types[qname] = {
+                    'kind': m.group('kind'),
+                    'oneway': False,
+                    'annotations': sorted(anns),
+                    'members': [],
+                }
+
+
+def dump_surface(aidl_root):
+    """Canonical text dump of every .aidl under aidl_root."""
+    types = {}
+    for dirpath, dirnames, filenames in os.walk(aidl_root):
+        dirnames.sort()
+        for fn in sorted(filenames):
+            if fn.endswith('.aidl'):
+                # errors='replace': stray non-UTF8 bytes (latin-1 NBSP has
+                # been seen in real corpora) must not abort the dump, and
+                # the replacement is deterministic.
+                with open(os.path.join(dirpath, fn), 'r',
+                          encoding='utf-8', errors='replace') as f:
+                    parse_aidl(f.read(), types)
+    lines = []
+    for qname in sorted(types):
+        t = types[qname]
+        head = ' '.join(
+            t['annotations']
+            + (['oneway'] if t['oneway'] else [])
+            + [t['kind'], qname])
+        lines.append(head)
+        lines.extend('    ' + m for m in t['members'])
+        lines.append('')
+    return '\n'.join(lines)
+
+
+# ---------------------------------------------------------------------------
+# Diffing two dumps
+# ---------------------------------------------------------------------------
+
+def parse_dump(text):
+    """Parse dump-surface output back into {qname: type} structures."""
+    types = {}
+    cur = None
+    for line in text.splitlines():
+        if not line.strip():
+            continue
+        if line.startswith('    '):
+            if cur is not None:
+                cur['members'].append(line.strip())
+            continue
+        anns, rest = _take_annotations(line)
+        parts = rest.split()
+        oneway = parts and parts[0] == 'oneway'
+        if oneway:
+            parts = parts[1:]
+        if len(parts) != 2 or parts[0] not in DECL_KINDS:
+            raise ValueError('bad dump header line: %r' % line)
+        cur = {
+            'kind': parts[0],
+            'oneway': oneway,
+            'annotations': sorted(anns),
+            'members': [],
+        }
+        types[parts[1]] = cur
+    return types
+
+
+def _member_name(kind, member):
+    """The identity of a member line: its declared name."""
+    if kind == 'enum' or member.startswith('const '):
+        return member.split('=')[0].split()[-1].strip()
+    m = re.match(r'[^(=]*?(\w+)\s*\(', member)   # method
+    if m:
+        return m.group(1)
+    return member.split('=')[0].split()[-1].strip()  # field
+
+
+def _diff_sequence(kind, where, old, new, added_kind, changes):
+    """Order-aware member diff. Removal/change/reorder = breaking;
+    append-only = major (declaration order is ABI)."""
+    old_names = [_member_name(kind, m) for m in old]
+    new_names = [_member_name(kind, m) for m in new]
+    new_by_name = dict(zip(new_names, new))
+    old_by_name = dict(zip(old_names, old))
+
+    for name, member in old_by_name.items():
+        if name not in new_by_name:
+            changes.append({
+                'class': 'breaking',
+                'kind': added_kind.replace('added', 'removed'),
+                'where': where, 'symbol': name, 'old': member,
+            })
+        elif new_by_name[name] != member:
+            changes.append({
+                'class': 'breaking',
+                'kind': added_kind.replace('added', 'changed'),
+                'where': where, 'symbol': name,
+                'old': member, 'new': new_by_name[name],
+            })
+    survivors = [n for n in old_names if n in new_by_name]
+    if new_names[:len(survivors)] != survivors:
+        changes.append({
+            'class': 'breaking',
+            'kind': added_kind.replace('added', 'reordered'),
+            'where': where,
+            'symbol': ', '.join(survivors),
+        })
+        return
+    for name in new_names[len(survivors):]:
+        if name not in old_by_name:
+            changes.append({
+                'class': 'major', 'kind': added_kind,
+                'where': where, 'symbol': new_by_name[name],
+            })
+
+
+def _diff_enum(where, old, new, changes):
+    """Enums match by name; backing int is the wire contract, not order."""
+    def as_map(members):
+        return {m.split('=')[0].strip(): m for m in members}
+    om, nm = as_map(old), as_map(new)
+    for name, member in sorted(om.items()):
+        if name not in nm:
+            changes.append({'class': 'breaking', 'kind': 'enum_value_removed',
+                            'where': where, 'symbol': name, 'old': member})
+        elif nm[name] != member:
+            changes.append({'class': 'breaking', 'kind': 'enum_value_changed',
+                            'where': where, 'symbol': name,
+                            'old': member, 'new': nm[name]})
+    for name, member in sorted(nm.items()):
+        if name not in om:
+            changes.append({'class': 'major', 'kind': 'enum_value_added',
+                            'where': where, 'symbol': member})
+
+
+def diff_surface(old_text, new_text):
+    """Classify new vs old dump: breaking / major / none + change list."""
+    old_types, new_types = parse_dump(old_text), parse_dump(new_text)
+    changes = []
+    for qname in sorted(set(old_types) | set(new_types)):
+        o, n = old_types.get(qname), new_types.get(qname)
+        if n is None:
+            changes.append({'class': 'breaking', 'kind': 'type_removed',
+                            'where': '%s %s' % (o['kind'], qname),
+                            'symbol': qname})
+            continue
+        if o is None:
+            changes.append({'class': 'major', 'kind': 'type_added',
+                            'where': '%s %s' % (n['kind'], qname),
+                            'symbol': qname})
+            continue
+        where = '%s %s' % (n['kind'], qname)
+        if o['kind'] != n['kind'] or o['oneway'] != n['oneway']:
+            changes.append({'class': 'breaking', 'kind': 'type_changed',
+                            'where': where, 'symbol': qname,
+                            'old': '%s%s' % ('oneway ' if o['oneway'] else '',
+                                             o['kind']),
+                            'new': '%s%s' % ('oneway ' if n['oneway'] else '',
+                                             n['kind'])})
+        removed = set(o['annotations']) - set(n['annotations'])
+        added = set(n['annotations']) - set(o['annotations'])
+        for a in sorted(removed):
+            changes.append({'class': 'breaking', 'kind': 'annotation_removed',
+                            'where': where, 'symbol': a})
+        for a in sorted(added):
+            # A new stability promise is additive; anything else (@Backing,
+            # @FixedSize, ...) changes the wire/ABI contract.
+            changes.append({
+                'class': 'major' if a == '@VintfStability' else 'breaking',
+                'kind': 'annotation_added', 'where': where, 'symbol': a})
+        if o['kind'] == 'enum':
+            _diff_enum(where, o['members'], n['members'], changes)
+        else:
+            o_const = [m for m in o['members'] if m.startswith('const ')]
+            n_const = [m for m in n['members'] if m.startswith('const ')]
+            o_rest = [m for m in o['members'] if not m.startswith('const ')]
+            n_rest = [m for m in n['members'] if not m.startswith('const ')]
+            _diff_enum(where, o_const, n_const, changes)  # consts: by name
+            member_kind = ('method_added' if o['kind'] == 'interface'
+                           else 'field_added')
+            _diff_sequence(o['kind'], where, o_rest, n_rest,
+                           member_kind, changes)
+    overall = 'none'
+    if any(c['class'] == 'breaking' for c in changes):
+        overall = 'breaking'
+    elif any(c['class'] == 'major' for c in changes):
+        overall = 'major'
+    for c in changes:
+        del c['class']
+    return {'class': overall, 'changes': changes}
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+def main(argv):
+    if not argv or argv[0] in ('-h', '--help', 'help'):
+        print(__doc__)
+        return 0
+    op, args = argv[0], argv[1:]
+    if op == 'dump-surface':
+        out = None
+        if '--out' in args:
+            i = args.index('--out')
+            if i + 1 >= len(args):
+                sys.stderr.write('dump-surface: --out needs a file\n')
+                return 2
+            out = args[i + 1]
+            args = args[:i] + args[i + 2:]
+        if len(args) != 1 or not os.path.isdir(args[0]):
+            sys.stderr.write(
+                'usage: dump-surface <aidl-root> [--out FILE]\n')
+            return 2
+        text = dump_surface(args[0])
+        if out:
+            with open(out, 'w') as f:
+                f.write(text)
+        else:
+            sys.stdout.write(text)
+        return 0
+    if op == 'diff-surface':
+        as_json = '--json' in args
+        args = [a for a in args if a != '--json']
+        if len(args) != 2:
+            sys.stderr.write(
+                'usage: diff-surface <old-dump> <new-dump> [--json]\n')
+            return 2
+        try:
+            texts = []
+            for p in args:
+                with open(p, 'r') as f:
+                    texts.append(f.read())
+            report = diff_surface(texts[0], texts[1])
+        except (OSError, ValueError) as e:
+            sys.stderr.write('diff-surface: %s\n' % e)
+            return 2
+        if as_json:
+            print(json.dumps(report, indent=2))
+        else:
+            print('class: %s' % report['class'])
+            for c in report['changes']:
+                line = '  %s  %s  %s' % (c['kind'], c['where'], c['symbol'])
+                if 'old' in c:
+                    line += '  [old: %s]' % c['old']
+                if 'new' in c:
+                    line += '  [new: %s]' % c['new']
+                print(line)
+        return 0
+    sys.stderr.write('aidl_surface: unknown operation %r\n' % op)
+    return 2
+
+
+if __name__ == '__main__':
+    sys.exit(main(sys.argv[1:]))

--- a/host/aidl_surface.py
+++ b/host/aidl_surface.py
@@ -58,6 +58,14 @@ _INT_RE = re.compile(r'^[+-]?(0[xX][0-9a-fA-F]+|\d+)$')
 # Parsing .aidl sources
 # ---------------------------------------------------------------------------
 
+def _string_end(text, i):
+    """Index just past the string literal starting at text[i] == '"'."""
+    j, n = i + 1, len(text)
+    while j < n and text[j] != '"':
+        j += 2 if text[j] == '\\' else 1
+    return min(j + 1, n)
+
+
 def strip_comments(text):
     """Remove // and /* */ comments, preserving string literals."""
     out = []
@@ -65,11 +73,9 @@ def strip_comments(text):
     while i < n:
         ch = text[i]
         if ch == '"':
-            j = i + 1
-            while j < n and text[j] != '"':
-                j += 2 if text[j] == '\\' else 1
-            out.append(text[i:j + 1])
-            i = j + 1
+            j = _string_end(text, i)
+            out.append(text[i:j])
+            i = j
         elif text.startswith('//', i):
             j = text.find('\n', i)
             i = n if j < 0 else j
@@ -84,13 +90,30 @@ def strip_comments(text):
 
 
 def _normalize(stmt):
-    """Collapse whitespace and normalize punctuation spacing."""
-    s = re.sub(r'\s+', ' ', stmt).strip()
-    s = re.sub(r'\s*([(),;=\[\]])\s*', r'\1', s)
-    s = s.replace(',', ', ').replace('=', ' = ')
-    s = re.sub(r'\](\w)', r'] \1', s)   # `Codec[] name`, not `Codec[]name`
-    # '(' after identifier stays tight; parameters got ', ' separators above.
-    return s.strip()
+    """Collapse whitespace and normalize punctuation spacing — but only
+    OUTSIDE string literals, so const/default string values are preserved
+    verbatim and a change inside a string always shows in the dump."""
+    out = ''
+    i, n = 0, len(stmt)
+    buf = ''
+
+    def flush(segment):
+        segment = re.sub(r'\s+', ' ', segment)
+        segment = re.sub(r'\s*([(),;=\[\]])\s*', r'\1', segment)
+        segment = segment.replace(',', ', ').replace('=', ' = ')
+        # `Codec[] name`, not `Codec[]name`; '(' after identifier stays tight.
+        return re.sub(r'\](\w)', r'] \1', segment)
+
+    while i < n:
+        if stmt[i] == '"':
+            j = _string_end(stmt, i)
+            out += flush(buf) + stmt[i:j]
+            buf = ''
+            i = j
+        else:
+            buf += stmt[i]
+            i += 1
+    return (out + flush(buf)).strip()
 
 
 def _split_statements(body):
@@ -103,10 +126,18 @@ def _split_statements(body):
     buf = ''
     while i < n:
         ch = body[i]
-        if ch == '{':
-            # matched-brace body for a nested declaration
+        if ch == '"':
+            # string literals are opaque: ; { } inside them are not structure
+            j = _string_end(body, i)
+            buf += body[i:j]
+            i = j
+        elif ch == '{':
+            # matched-brace body for a nested declaration (string-aware)
             depth, j = 1, i + 1
             while j < n and depth:
+                if body[j] == '"':
+                    j = _string_end(body, j)
+                    continue
                 depth += {'{': 1, '}': -1}.get(body[j], 0)
                 j += 1
             yield ('decl', (buf.strip(), body[i + 1:j - 1]))

--- a/host/aidl_surface.py
+++ b/host/aidl_surface.py
@@ -190,11 +190,12 @@ def parse_aidl(text, types):
     """Parse one .aidl file's text into the types dict."""
     text = strip_comments(text)
     package = ''
-    pm = re.search(r'\bpackage\s+([\w.]+)\s*;', text)
+    pm = re.search(r'^\s*package\s+([\w.]+)\s*;', text, re.M)
     if pm:
         package = pm.group(1)
     # Remove package/import statements, then parse top-level declarations.
-    text = re.sub(r'\b(package|import)\s+[\w.*]+\s*;', '', text)
+    text = re.sub(r'^\s*(package|import)\s+[\w.*]+\s*;', '', text,
+                  flags=re.M)
     for skind, item in _split_statements(text):
         if skind == 'decl':
             _parse_type(item[0], item[1], package, '', types)
@@ -320,22 +321,26 @@ def _diff_sequence(kind, where, old, new, added_kind, changes):
             })
 
 
-def _diff_enum(where, old, new, changes):
-    """Enums match by name; backing int is the wire contract, not order."""
+def _diff_enum(where, old, new, changes, prefix='enum_value'):
+    """Enums/consts match by declared name; the backing int / value is the
+    wire contract, not order. `prefix` names the change kinds
+    (enum_value_* or const_*)."""
     def as_map(members):
-        return {m.split('=')[0].strip(): m for m in members}
+        # Key by the declared identifier (last word before '='), so a
+        # const type change reports as one *_changed, not removed+added.
+        return {m.split('=')[0].split()[-1].strip(): m for m in members}
     om, nm = as_map(old), as_map(new)
     for name, member in sorted(om.items()):
         if name not in nm:
-            changes.append({'class': 'breaking', 'kind': 'enum_value_removed',
+            changes.append({'class': 'breaking', 'kind': prefix + '_removed',
                             'where': where, 'symbol': name, 'old': member})
         elif nm[name] != member:
-            changes.append({'class': 'breaking', 'kind': 'enum_value_changed',
+            changes.append({'class': 'breaking', 'kind': prefix + '_changed',
                             'where': where, 'symbol': name,
                             'old': member, 'new': nm[name]})
     for name, member in sorted(nm.items()):
         if name not in om:
-            changes.append({'class': 'major', 'kind': 'enum_value_added',
+            changes.append({'class': 'major', 'kind': prefix + '_added',
                             'where': where, 'symbol': member})
 
 
@@ -381,7 +386,7 @@ def diff_surface(old_text, new_text):
             n_const = [m for m in n['members'] if m.startswith('const ')]
             o_rest = [m for m in o['members'] if not m.startswith('const ')]
             n_rest = [m for m in n['members'] if not m.startswith('const ')]
-            _diff_enum(where, o_const, n_const, changes)  # consts: by name
+            _diff_enum(where, o_const, n_const, changes, prefix='const')
             member_kind = ('method_added' if o['kind'] == 'interface'
                            else 'field_added')
             _diff_sequence(o['kind'], where, o_rest, n_rest,
@@ -420,7 +425,7 @@ def main(argv):
             return 2
         text = dump_surface(args[0])
         if out:
-            with open(out, 'w') as f:
+            with open(out, 'w', encoding='utf-8', newline='\n') as f:
                 f.write(text)
         else:
             sys.stdout.write(text)
@@ -435,7 +440,8 @@ def main(argv):
         try:
             texts = []
             for p in args:
-                with open(p, 'r') as f:
+                with open(p, 'r', encoding='utf-8',
+                          errors='replace') as f:
                     texts.append(f.read())
             report = diff_surface(texts[0], texts[1])
         except (OSError, ValueError) as e:

--- a/tests/README.md
+++ b/tests/README.md
@@ -20,6 +20,7 @@ not a failure). The runner exits non-zero if any test fails.
 | `test_binder_4_9_fallbacks.sh` | binder builds against 4.9 kernel UAPI headers (#35) |
 | `test_cmake_min_version_compat.sh` | no CMake sub-command newer than the declared `cmake_minimum_required` (#24) |
 | `test_interface_version_ordinal.py` | module-local snapshots emit the real interface VERSION ordinal (#32) |
+| `test_surface_dump_diff.py` | `dump-surface` / `diff-surface` classification rule table (#27) |
 | `test_qemu_binder.sh` → [`qemu/`](qemu/) | binder **round-trip on a real kernel** under QEMU — the runtime gate for the kernel-floor / protocol / bitness work (#35/#36) |
 
 ## QEMU binder round-trip (`qemu/`)

--- a/tests/test_surface_dump_diff.py
+++ b/tests/test_surface_dump_diff.py
@@ -72,7 +72,8 @@ enum Mode {
 def dump(*sources):
     with tempfile.TemporaryDirectory() as d:
         for i, src in enumerate(sources):
-            with open(os.path.join(d, "f%d.aidl" % i), "w") as f:
+            with open(os.path.join(d, "f%d.aidl" % i), "w",
+                      encoding="utf-8") as f:
                 f.write(src)
         return aidl_surface.dump_surface(d)
 
@@ -195,12 +196,26 @@ class TestDiffRuleTable(unittest.TestCase):
             "const @utf8InCpp String serviceName = \"thing\";",
             "const @utf8InCpp String serviceName = \"thing\";\n"
             "    const int LIMIT = 4;")
-        self.assertClass("major", [BASE_IFACE], [new], "enum_value_added")
+        self.assertClass("major", [BASE_IFACE], [new], "const_added")
+
+    def test_const_type_changed_is_single_change(self):
+        new = BASE_IFACE.replace("const @utf8InCpp String serviceName",
+                                 "const String serviceName")
+        report = classify([BASE_IFACE], [new])
+        self.assertEqual("breaking", report["class"])
+        kinds = [c["kind"] for c in report["changes"]]
+        self.assertEqual(["const_changed"], kinds, report)
+
+    def test_package_string_literal_not_misparsed(self):
+        src = BASE_IFACE.replace(
+            'serviceName = "thing"',
+            'serviceName = "package com.fake; import x.Y;"')
+        self.assertIn("com.rdk.test.IThing", dump(src))
 
     def test_const_changed_breaking(self):
         new = BASE_IFACE.replace('= "thing"', '= "other"')
         self.assertClass("breaking", [BASE_IFACE], [new],
-                         "enum_value_changed")
+                         "const_changed")
 
 
 class TestCli(unittest.TestCase):
@@ -209,7 +224,8 @@ class TestCli(unittest.TestCase):
         with tempfile.TemporaryDirectory() as d:
             src_dir = os.path.join(d, "aidl")
             os.makedirs(src_dir)
-            with open(os.path.join(src_dir, "IThing.aidl"), "w") as f:
+            with open(os.path.join(src_dir, "IThing.aidl"), "w",
+                      encoding="utf-8") as f:
                 f.write(BASE_IFACE)
             old = os.path.join(d, "old.txt")
             new = os.path.join(d, "new.txt")

--- a/tests/test_surface_dump_diff.py
+++ b/tests/test_surface_dump_diff.py
@@ -1,0 +1,234 @@
+#!/usr/bin/env python3
+#/**
+# * Copyright 2026 RDK Management
+# *
+# * Licensed under the Apache License, Version 2.0 (the "License");
+# * you may not use this file except in compliance with the License.
+# * You may obtain a copy of the License at
+# *
+# * http://www.apache.org/licenses/LICENSE-2.0
+# *
+# * Unless required by applicable law or agreed to in writing, software
+# * distributed under the License is distributed on an "AS IS" BASIS,
+# * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# * See the License for the specific language governing permissions and
+# * limitations under the License.
+# *
+# * SPDX-License-Identifier: Apache-2.0
+# */
+#
+# Regression test for issue #27 — `aidl_ops dump-surface` / `diff-surface`.
+#
+# Exercises the classification rule table: every row maps a structural AIDL
+# change to breaking / major / none. Declaration order is ABI (transaction
+# ids / parcel order), so removal, change and reordering are breaking while
+# append-only changes are major. Doc-comment-only edits must produce
+# byte-identical dumps.
+#
+# Run: python3 tests/test_surface_dump_diff.py   (exit 0 = pass)
+
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+
+HOST_DIR = os.path.join(
+    os.path.dirname(os.path.abspath(__file__)), "..", "host")
+sys.path.insert(0, HOST_DIR)
+import aidl_surface  # noqa: E402
+
+BASE_IFACE = """
+package com.rdk.test;
+/** Doc comment. */
+@VintfStability
+interface IThing {
+    const @utf8InCpp String serviceName = "thing";
+    void alpha(in int a);
+    int beta(in String b, out long[] c);
+}
+"""
+
+BASE_PARCEL = """
+package com.rdk.test;
+@VintfStability
+parcelable Config {
+    int width;
+    @nullable String label;
+}
+"""
+
+BASE_ENUM = """
+package com.rdk.test;
+@Backing(type="int") @VintfStability
+enum Mode {
+    OFF = 0,
+    ON = 1,
+    AUTO,
+}
+"""
+
+
+def dump(*sources):
+    with tempfile.TemporaryDirectory() as d:
+        for i, src in enumerate(sources):
+            with open(os.path.join(d, "f%d.aidl" % i), "w") as f:
+                f.write(src)
+        return aidl_surface.dump_surface(d)
+
+
+def classify(old, new):
+    return aidl_surface.diff_surface(dump(*old), dump(*new))
+
+
+class TestDump(unittest.TestCase):
+
+    def test_deterministic(self):
+        self.assertEqual(dump(BASE_IFACE, BASE_PARCEL, BASE_ENUM),
+                         dump(BASE_IFACE, BASE_PARCEL, BASE_ENUM))
+
+    def test_doc_comments_stripped(self):
+        redocumented = BASE_IFACE.replace(
+            "/** Doc comment. */", "/** A totally different doc. */")
+        self.assertEqual(dump(BASE_IFACE), dump(redocumented))
+
+    def test_implicit_enum_backing_ints(self):
+        self.assertIn("AUTO = 2", dump(BASE_ENUM))
+
+    def test_nested_type(self):
+        src = """
+        package com.rdk.test;
+        @VintfStability
+        parcelable Outer {
+            parcelable Id { int value; }
+            int x;
+        }
+        """
+        text = dump(src)
+        self.assertIn("parcelable com.rdk.test.Outer.Id", text)
+        self.assertIn("parcelable com.rdk.test.Outer\n    int x", text)
+
+
+class TestDiffRuleTable(unittest.TestCase):
+    """One test per row of the #27 classification rule table."""
+
+    def assertClass(self, expected, old, new, kind=None):
+        report = classify(old, new)
+        self.assertEqual(expected, report["class"], report)
+        if kind:
+            self.assertIn(kind, [c["kind"] for c in report["changes"]],
+                          report)
+
+    def test_no_change_is_none(self):
+        self.assertClass("none", [BASE_IFACE, BASE_ENUM],
+                         [BASE_IFACE, BASE_ENUM])
+
+    def test_method_removed_breaking(self):
+        new = BASE_IFACE.replace("void alpha(in int a);", "")
+        self.assertClass("breaking", [BASE_IFACE], [new], "method_removed")
+
+    def test_method_signature_changed_breaking(self):
+        new = BASE_IFACE.replace("void alpha(in int a);",
+                                 "void alpha(in long a);")
+        self.assertClass("breaking", [BASE_IFACE], [new], "method_changed")
+
+    def test_method_added_at_end_major(self):
+        new = BASE_IFACE.replace(
+            "}", "    void gamma();\n}")
+        self.assertClass("major", [BASE_IFACE], [new], "method_added")
+
+    def test_method_inserted_mid_list_breaking(self):
+        new = BASE_IFACE.replace(
+            "void alpha(in int a);",
+            "void alpha(in int a);\n    void inserted();")
+        self.assertClass("breaking", [BASE_IFACE], [new],
+                         "method_reordered")
+
+    def test_field_removed_breaking(self):
+        new = BASE_PARCEL.replace("int width;", "")
+        self.assertClass("breaking", [BASE_PARCEL], [new], "field_removed")
+
+    def test_field_reordered_breaking(self):
+        new = BASE_PARCEL.replace(
+            "int width;\n    @nullable String label;",
+            "@nullable String label;\n    int width;")
+        self.assertClass("breaking", [BASE_PARCEL], [new],
+                         "field_reordered")
+
+    def test_field_type_changed_breaking(self):
+        new = BASE_PARCEL.replace("int width;", "long width;")
+        self.assertClass("breaking", [BASE_PARCEL], [new], "field_changed")
+
+    def test_field_appended_major(self):
+        new = BASE_PARCEL.replace("}", "    int height;\n}")
+        self.assertClass("major", [BASE_PARCEL], [new], "field_added")
+
+    def test_enum_value_removed_breaking(self):
+        new = BASE_ENUM.replace("AUTO,", "")
+        self.assertClass("breaking", [BASE_ENUM], [new],
+                         "enum_value_removed")
+
+    def test_enum_backing_int_changed_breaking(self):
+        new = BASE_ENUM.replace("ON = 1,", "ON = 5,")
+        self.assertClass("breaking", [BASE_ENUM], [new],
+                         "enum_value_changed")
+
+    def test_enum_value_added_major(self):
+        new = BASE_ENUM.replace("}", "    ECO = 7,\n}")
+        self.assertClass("major", [BASE_ENUM], [new], "enum_value_added")
+
+    def test_vintf_stability_removed_breaking(self):
+        new = BASE_PARCEL.replace("@VintfStability\n", "")
+        self.assertClass("breaking", [BASE_PARCEL], [new],
+                         "annotation_removed")
+
+    def test_new_type_added_major(self):
+        self.assertClass("major", [BASE_IFACE], [BASE_IFACE, BASE_PARCEL],
+                         "type_added")
+
+    def test_type_removed_breaking(self):
+        self.assertClass("breaking", [BASE_IFACE, BASE_PARCEL],
+                         [BASE_IFACE], "type_removed")
+
+    def test_const_added_major(self):
+        new = BASE_IFACE.replace(
+            "const @utf8InCpp String serviceName = \"thing\";",
+            "const @utf8InCpp String serviceName = \"thing\";\n"
+            "    const int LIMIT = 4;")
+        self.assertClass("major", [BASE_IFACE], [new], "enum_value_added")
+
+    def test_const_changed_breaking(self):
+        new = BASE_IFACE.replace('= "thing"', '= "other"')
+        self.assertClass("breaking", [BASE_IFACE], [new],
+                         "enum_value_changed")
+
+
+class TestCli(unittest.TestCase):
+
+    def test_aidl_ops_dispatch_round_trip(self):
+        with tempfile.TemporaryDirectory() as d:
+            src_dir = os.path.join(d, "aidl")
+            os.makedirs(src_dir)
+            with open(os.path.join(src_dir, "IThing.aidl"), "w") as f:
+                f.write(BASE_IFACE)
+            old = os.path.join(d, "old.txt")
+            new = os.path.join(d, "new.txt")
+            ops = os.path.join(HOST_DIR, "aidl_ops.py")
+            for out in (old, new):
+                rc = subprocess.call(
+                    [sys.executable, ops, "dump-surface", src_dir,
+                     "--out", out])
+                self.assertEqual(0, rc)
+            out = subprocess.run(
+                [sys.executable, ops, "diff-surface", old, new, "--json"],
+                capture_output=True, text=True)
+            self.assertEqual(0, out.returncode, out.stderr)
+            self.assertIn('"class": "none"', out.stdout)
+
+
+if __name__ == "__main__":
+    result = unittest.main(exit=False, verbosity=1).result
+    ok = result.wasSuccessful()
+    print("%s: test_surface_dump_diff (%d tests)"
+          % ("PASS" if ok else "FAIL", result.testsRun))
+    sys.exit(0 if ok else 1)

--- a/tests/test_surface_dump_diff.py
+++ b/tests/test_surface_dump_diff.py
@@ -210,7 +210,30 @@ class TestDiffRuleTable(unittest.TestCase):
         src = BASE_IFACE.replace(
             'serviceName = "thing"',
             'serviceName = "package com.fake; import x.Y;"')
-        self.assertIn("com.rdk.test.IThing", dump(src))
+        text = dump(src)
+        self.assertIn("com.rdk.test.IThing", text)
+        # the literal survives verbatim and the statement is not split on
+        # the embedded semicolon
+        self.assertIn('"package com.fake; import x.Y;"', text)
+        self.assertNotIn("com.fake", text.split('"')[0])
+
+    def test_structural_chars_in_string_literal(self):
+        src = BASE_IFACE.replace(
+            'serviceName = "thing"',
+            'serviceName = "a;b{c}d"')
+        text = dump(src)
+        self.assertIn('"a;b{c}d"', text)
+        # all members still parsed after the tricky const
+        self.assertIn("void alpha(in int a)", text)
+        self.assertIn("int beta(in String b, out long[] c)", text)
+
+    def test_whitespace_inside_string_is_a_real_change(self):
+        new = BASE_IFACE.replace('= "thing"', '= "th  ing"')
+        self.assertIn('"th  ing"', dump(new))   # preserved verbatim
+        report = classify([BASE_IFACE], [new])
+        self.assertEqual("breaking", report["class"])
+        self.assertEqual(["const_changed"],
+                         [c["kind"] for c in report["changes"]], report)
 
     def test_const_changed_breaking(self):
         new = BASE_IFACE.replace('= "thing"', '= "other"')


### PR DESCRIPTION
Closes #27.

## What
Two new `aidl_ops` subcommands, implemented in a new self-contained `host/aidl_surface.py` (stdlib only, no built binary needed):

- **`dump-surface <aidl-root> [--out FILE]`** — canonical, deterministic text dump of the declared AIDL surface: interfaces / parcelables / unions / enums (incl. nested types), method signatures, field types + defaults, consts, enum values with computed backing ints, annotations. Comments stripped; types sorted by qualified name; members in declaration order (order is ABI: transaction ids / parcel layout).
- **`diff-surface <old> <new> [--json]`** — structural compare of two dumps, classified per the issue's rule table: member removed / signature changed / reordered, enum backing-int changed, annotation changed → **breaking**; append-only members, new enum values, new types → **major**; identical → **none**. Doc-only edits yield byte-identical dumps by construction (the consumer's doc-only signal).

## Validation
- **22-test regression suite** (`tests/test_surface_dump_diff.py`, auto-discovered by `run-tests.sh`) — one test per rule-table row plus determinism, comment-stripping, implicit enum ints, nested types, and an `aidl_ops` dispatch round-trip.
- **Real-corpus check (rdk-halif-aidl):** all 22 components dump cleanly + deterministically; the historical `audiodecoder 0.1.0.0 → 0.2.0.0` evolution classifies **breaking** — matching the major bump that was actually made; a freshly-frozen snapshot vs `current` classifies **none**.
- Full suite: 5/6 pass; `test_yocto_m4_regression.sh` fails identically on clean develop (pre-existing, unrelated).

## Consumer mapping (rdk-halif-aidl `<pre-post-aidl>.<major>.<minor>.<bugfix>`)
`breaking` ⇒ major bump · `major` (additive) ⇒ minor bump · equal dumps + differing sources ⇒ doc/bugfix bump. The release-side audit gate consuming this is the remaining scope of rdk-halif-aidl#633.

## Notes
- Overall `class` is `breaking` > `major` > `none`; `minor` is never emitted by the tool itself since doc-only changes are invisible in dumps (documented in README).
- Documented in README.md with example invocations; tests/README.md table updated.