### PR TITLE
build: add @agampa263 as CODEOWNERS reviewer for tests/ (#49)

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,3 @@
+
+# Test harnesses: request review from the AIDL HAL / binder tester.
+/tests/ @rdkcentral/binder-aidl-maintainers @agampa263


### PR DESCRIPTION
Closes #49. Adds Akshaykumar Gampa (@agampa263, akshaykumar_gampa@comcast.com — tester for the binder/AIDL toolchain) as a CODEOWNERS reviewer on `tests/`, alongside the existing maintainers team. He has write access, so the rule is effective.