### PR TITLE
fix: move tests/ CODEOWNERS rule into .github/CODEOWNERS (#49)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,3 +3,6 @@
 # @global-owner1 and @global-owner2 will be requested for
 # review when someone opens a pull request.
 *       @rdkcentral/binder-aidl-maintainers
+
+# Test harnesses: request review from the AIDL HAL / binder tester.
+/tests/ @rdkcentral/binder-aidl-maintainers @agampa263

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,3 +1,0 @@
-
-# Test harnesses: request review from the AIDL HAL / binder tester.
-/tests/ @rdkcentral/binder-aidl-maintainers @agampa263


### PR DESCRIPTION
Refs #49. #50 added the `tests/` rule to a new root-level `CODEOWNERS`, but this repo's honored file is `.github/CODEOWNERS` (GitHub uses .github/ with precedence over root), so the rule was ineffective. This moves the rule into `.github/CODEOWNERS` and removes the root duplicate.