### PR TITLE
Revert tests/ CODEOWNERS rule (backs out #50/#51)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,6 +3,3 @@
 # @global-owner1 and @global-owner2 will be requested for
 # review when someone opens a pull request.
 *       @rdkcentral/binder-aidl-maintainers
-
-# Test harnesses: request review from the AIDL HAL / binder tester.
-/tests/ @rdkcentral/binder-aidl-maintainers @agampa263


### PR DESCRIPTION
Backs out the `/tests/` CODEOWNERS rule added by #50 and relocated by #51, restoring `.github/CODEOWNERS` to its prior state (default `@rdkcentral/binder-aidl-maintainers` only). Refs #49.